### PR TITLE
Removed the default 'wp_' prefix for table names

### DIFF
--- a/src/Corcel/Comment.php
+++ b/src/Corcel/Comment.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
 
 /**
  * Corcel\Comment
- * 
+ *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
 
@@ -12,12 +12,12 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class Comment extends Eloquent
 {
-    protected $table = 'wp_comments';
+    protected $table = 'comments';
     protected $primaryKey = 'comment_ID';
 
     /**
      * Post relationship
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function post()
@@ -27,7 +27,7 @@ class Comment extends Eloquent
 
     /**
      * Original relationship
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function original()
@@ -37,7 +37,7 @@ class Comment extends Eloquent
 
     /**
      * Replies relationship
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function replies()
@@ -47,7 +47,7 @@ class Comment extends Eloquent
 
     /**
      * Verify if the current comment is approved
-     * 
+     *
      * @return bool
      */
     public function isApproved()
@@ -57,7 +57,7 @@ class Comment extends Eloquent
 
     /**
      * Verify if the current comment is a reply from another comment
-     * 
+     *
      * @return bool
      */
     public function isReply()
@@ -67,7 +67,7 @@ class Comment extends Eloquent
 
     /**
      * Verify if the current comment has replies
-     * 
+     *
      * @return bool
      */
     public function hasReplies()
@@ -77,7 +77,7 @@ class Comment extends Eloquent
 
     /**
      * Find a comment by post ID
-     * 
+     *
      * @param int $postId
      * @return \Corcel\Comment
      */
@@ -89,7 +89,7 @@ class Comment extends Eloquent
 
     /**
      * Override the parent newQuery() to the custom CommentBuilder class
-     * 
+     *
      * @param bool $excludeDeleted
      * @return \Corcel\CommentBuilder
      */

--- a/src/Corcel/Database.php
+++ b/src/Corcel/Database.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
 
 /**
  * Corcel\Database
- * 
+ *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
 
@@ -20,12 +20,12 @@ class Database
         'host'      => 'localhost',
         'charset'   => 'utf8',
         'collation' => 'utf8_unicode_ci',
-        'prefix'    => '',
+        'prefix'    => 'wp_',
     );
 
     /**
      * Connect to the Wordpress database
-     * 
+     *
      * @param array $params
      */
     public static function connect(array $params)
@@ -33,7 +33,7 @@ class Database
         $capsule = new Capsule;
         $params = array_merge(static::$baseParams, $params);
         $capsule->addConnection($params);
-        $capsule->bootEloquent();        
+        $capsule->bootEloquent();
     }
 }
 

--- a/src/Corcel/Post.php
+++ b/src/Corcel/Post.php
@@ -15,7 +15,7 @@ class Post extends Eloquent
     const CREATED_AT = 'post_date';
     const UPDATED_AT = 'post_modified';
 
-    protected $table = 'wp_posts';
+    protected $table = 'posts';
     protected $primaryKey = 'ID';
     protected $with = array('meta');
 
@@ -41,7 +41,7 @@ class Post extends Eloquent
      */
     public function taxonomies()
     {
-        return $this->belongsToMany('Corcel\TermTaxonomy', 'wp_term_relationships', 'object_id', 'term_taxonomy_id');
+        return $this->belongsToMany('Corcel\TermTaxonomy', 'term_relationships', 'object_id', 'term_taxonomy_id');
     }
 
     /**

--- a/src/Corcel/PostMeta.php
+++ b/src/Corcel/PostMeta.php
@@ -1,8 +1,8 @@
-<?php 
+<?php
 
 /**
  * Corcel\PostMeta
- * 
+ *
  * @author Junior Grossi <juniorgro@gmail.com>
  */
 
@@ -12,14 +12,14 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class PostMeta extends Eloquent
 {
-    protected $table = 'wp_postmeta';
+    protected $table = 'postmeta';
     protected $primaryKey = 'meta_id';
     public $timestamps = false;
     protected $fillable = array('meta_key', 'meta_value', 'post_id');
 
     /**
      * Post relationship
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function post()
@@ -29,7 +29,7 @@ class PostMeta extends Eloquent
 
     /**
      * Override newCollection() to return a custom collection
-     * 
+     *
      * @param array $models
      * @return \Corcel\PostMetaCollection
      */

--- a/src/Corcel/Term.php
+++ b/src/Corcel/Term.php
@@ -6,6 +6,6 @@ use \Illuminate\Database\Eloquent\Model as Eloquent;
 
 class Term extends Eloquent
 {
-    protected $table = 'wp_terms';
+    protected $table = 'terms';
     protected $primaryKey = 'term_id';
 }

--- a/src/Corcel/TermRelationship.php
+++ b/src/Corcel/TermRelationship.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class TermRelationship extends Model
 {
-    protected $table = 'wp_term_relationships';
+    protected $table = 'term_relationships';
     protected $primaryKey = array('object_id', 'term_taxonomy_id');
 
     public function post()

--- a/src/Corcel/TermTaxonomy.php
+++ b/src/Corcel/TermTaxonomy.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class TermTaxonomy extends Model
 {
-    protected $table = 'wp_term_taxonomy';
+    protected $table = 'term_taxonomy';
     protected $primaryKey = 'term_taxonomy_id';
     protected $with = array('term');
 
@@ -22,7 +22,7 @@ class TermTaxonomy extends Model
 
     public function posts()
     {
-        return $this->belongsToMany('Corcel\Post', 'wp_term_relationships', 'term_taxonomy_id', 'object_id');
+        return $this->belongsToMany('Corcel\Post', 'term_relationships', 'term_taxonomy_id', 'object_id');
     }
 
     /**


### PR DESCRIPTION
Removed the wp_ prefix from the tables, allowing use the default
laravel connection table prefix. For a non laravel applications, the default
prefix can be set in corcel connection params.
