### PR TITLE
Querying multiple post types

### DIFF
--- a/src/PostBuilder.php
+++ b/src/PostBuilder.php
@@ -50,7 +50,7 @@ class PostBuilder extends Builder
      * @param array $type
      * @return \Corcel\PostBuilder
      */
-    public function type($type)
+    public function typeIn($type)
     {
         return $this->whereIn('post_type', $type);
     }

--- a/src/PostBuilder.php
+++ b/src/PostBuilder.php
@@ -44,6 +44,17 @@ class PostBuilder extends Builder
         return $this->where('post_type', $type);
     }
 
+    /**
+     * Get only posts from an array of custom post types
+     * 
+     * @param array $type
+     * @return \Corcel\PostBuilder
+     */
+    public function type($type)
+    {
+        return $this->whereIn('post_type', $type);
+    }
+
     public function taxonomy($taxonomy, $term)
     {
         return $this->whereHas('taxonomies', function($query) use ($taxonomy, $term) {


### PR DESCRIPTION
Eloquent supports the whereIn method, but Corcel until now has not made use of it. My use case required me to query multiple post types in the one transaction.

Example:
```php
$posts = Post::typeIn(['post', 'recipe'])->status('publish')->get();
```