### PR TITLE
Options model

### DIFF
--- a/models/Options.php
+++ b/models/Options.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Options class.
+ *
+ * @author José CI <josec89@gmail.com>
+ */
+class Options extends Corcel\Options
+{
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/config/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Corcel Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">app/</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
+    </php>
+</phpunit>

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Corcel;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+/**
+ * Options class.
+ *
+ * @author José CI <josec89@gmail.com>
+ */
+class Options extends Eloquent
+{
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'options';
+    /**
+     * The primary key of the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'option_id';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'option_name',
+        'option_value',
+        'autoload',
+    ];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = ['value'];
+
+    /**
+     * Gets the value.
+     * Tries to unserialize the object and returns the value if that doesn't work.
+     *
+     * @return value
+     */
+    public function getValueAttribute()
+    {
+        try {
+            return unserialize($this->option_value);
+        } catch (Exception $ex) {
+            return $this->option_value;
+        }
+    }
+
+    /**
+     * Gets option field by its name.
+     *
+     * @param string $name
+     *
+     * @return string|array
+     */
+    public static function get($name)
+    {
+        if ($option = self::where('option_name', $name)->first()) {
+            return $option->value;
+        }
+
+        return;
+    }
+
+    /**
+     * Gets all the options.
+     *
+     * @return array
+     */
+    public static function getAll()
+    {
+        $options = self::all();
+        $result = [];
+        foreach ($options as $option) {
+            $result[$option->option_name] = $option->value;
+        }
+
+        return $result;
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Corcel\Options;
+
+class OptionsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test getting some options.
+     */
+    public function testGetOptions()
+    {
+        // Get all the options and test some
+        $options = Options::getAll();
+        $this->assertNotNull($options);
+
+        // String value
+        $this->assertArrayHasKey('blogname', $options);
+        $this->assertEquals('Wordpress Corcel', $options['blogname']);
+
+        // Array value
+        $this->assertArrayHasKey('wp_user_roles', $options);
+        $this->assertCount(5, $options['wp_user_roles']);
+        $this->assertEquals('Administrator', $options['wp_user_roles']['administrator']['name']);
+
+        // Get single values
+        $this->assertEquals('juniorgro@gmail.com', Options::get('admin_email'));
+        $this->assertEquals(false, Options::get('moderation_keys'));
+
+        $themeRoots = Options::get('_site_transient_theme_roots');
+        $this->assertNotNull($themeRoots);
+        $this->assertEquals('/themes', $themeRoots['twentyfourteen']);
+    }
+}


### PR DESCRIPTION
```
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from /home/vagrant/projects/corcel/phpunit.xml

...........................

Time: 427 ms, Memory: 10.00Mb

OK (27 tests, 226 assertions)
```

- `phpunit.xml` file added so as to ease the testing process
- Options model added with static methods to get options by name or get all
- Options tests