### PR TITLE
Unserializes `meta` values whenever it's possible

### DIFF
--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -8,6 +8,7 @@
 
 namespace Corcel;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class PostMeta extends Eloquent
@@ -30,6 +31,28 @@ class PostMeta extends Eloquent
         }
 
         return $this->belongsTo('Corcel\Post');
+    }
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = ['value'];
+
+    /**
+     * Gets the value.
+     * Tries to unserialize the object and returns the value if that doesn't work.
+     *
+     * @return value
+     */
+    public function getValueAttribute()
+    {
+        try {
+            return unserialize($this->meta_value);
+        } catch (Exception $ex) {
+            return $this->meta_value;
+        }
     }
 
     /**


### PR DESCRIPTION
This is useful when you have Advanced Field Plugins or any other plugin which uses *serialized* values. It keeps the original (serialized) value and adds a new value: The PHP object if it can be unserialized, the original value otherwise

Example (ACF Gallery)
```
    2 => array:5 [
      "meta_id" => 14
      "post_id" => 4
      "meta_key" => "cool_gallery"
      "meta_value" => "a:2:{i:0;s:1:"9";i:1;s:1:"8";}"
      "value" => array:2 [
        0 => "9"
        1 => "8"
      ]
    ]
```

```
PHPUnit 4.2.2 by Sebastian Bergmann.

...........................

Time: 463 ms, Memory: 10.00Mb

OK (27 tests, 234 assertions)
```