### PR TITLE
import Str class in Model

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
 
 class Model extends Eloquent
 {

--- a/tests/PostMetaTest.php
+++ b/tests/PostMetaTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Corcel\Post;
+use Corcel\Page;
+use Corcel\PostMeta;
+
+class PostMetaTest extends PHPUnit_Framework_TestCase
+{
+    public function testPostMetaConstructor()
+    {
+        $postmeta = new PostMeta();
+        $this->assertTrue($postmeta instanceof \Corcel\PostMeta);
+    }
+
+    public function testPostId()
+    {
+        $postmeta = PostMeta::find(1);
+
+        if ($postmeta) {
+            $this->assertEquals($postmeta->meta_id, 1);
+        } else {
+            $this->assertEquals($postmeta, null);
+        }
+    }
+
+    public function testPostRelation()
+    {
+        $postmeta = PostMeta::find(1);
+        $this->assertTrue($postmeta->post instanceof \Corcel\Post);
+    }
+}


### PR DESCRIPTION
As per #99 this fix adds the use statement to the top of Model to import the Str class
Also added a new test class for PostMeta in order to test that this change works. 

```
Testing started at 21:31 ...
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from C:\xampp\htdocs\corcel\phpunit.xml



Time: 1.45 seconds, Memory: 8.00Mb

OK (39 tests, 322 assertions)

Process finished with exit code 0
```