### PR TITLE
Fix postmeta value

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -52,7 +52,11 @@ class Options extends Eloquent
     public function getValueAttribute()
     {
         try {
-            return unserialize($this->option_value);
+            $value = unserialize($this->option_value);
+            // if we get false, but the original value is not false then something has gone wrong.
+            // return the option_value as is instead of unserializing
+            // added this to handle cases where unserialize doesn't throw an error that is catchable
+            return $value === false && $this->option_value !== false ? $this->option_value : $value;
         } catch (Exception $ex) {
             return $this->option_value;
         }

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -48,7 +48,11 @@ class PostMeta extends Model
     public function getValueAttribute()
     {
         try {
-            return unserialize($this->meta_value);
+            $value = unserialize($this->meta_value);
+            // if we get false, but the original value is not false then something has gone wrong.
+            // return the meta_value as is instead of unserializing
+            // added this to handle cases where unserialize doesn't throw an error that is catchable
+            return $value === false && $this->meta_value !== false ? $this->meta_value : $value;
         } catch (Exception $ex) {
             return $this->meta_value;
         }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -30,4 +30,19 @@ class OptionsTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($themeRoots);
         $this->assertEquals('/themes', $themeRoots['twentyfourteen']);
     }
+
+    public function testOptionValue()
+    {
+        //test value when option_value is string
+        $optionWithString = Options::find(1);
+        $stringValue = '2016-04-03';
+        $optionWithString->option_value = $stringValue;
+        $this->assertEquals($stringValue, $optionWithString->value);
+
+        //test value when option_value is serialized array
+        $optionWithArray = Options::find(1);
+        $arrayValue = ['key' => 'value'];
+        $optionWithArray->option_value = serialize($arrayValue);
+        $this->assertEquals($arrayValue, $optionWithArray->value);
+    }
 }

--- a/tests/PostMetaTest.php
+++ b/tests/PostMetaTest.php
@@ -28,4 +28,19 @@ class PostMetaTest extends PHPUnit_Framework_TestCase
         $postmeta = PostMeta::find(1);
         $this->assertTrue($postmeta->post instanceof \Corcel\Post);
     }
+
+    public function testPostMetaValue()
+    {
+        //test value when meta_value is string
+        $metaWithString = PostMeta::find(1);
+        $stringValue = '2016-04-03';
+        $metaWithString->meta_value = $stringValue;
+        $this->assertEquals($stringValue, $metaWithString->value);
+
+        //test value when meta_value is serialized array
+        $metaWithArray = PostMeta::find(1);
+        $arrayValue = ['key' => 'value'];
+        $metaWithArray->meta_value = serialize($arrayValue);
+        $this->assertEquals($arrayValue, $metaWithArray->value);
+    }
 }


### PR DESCRIPTION
Updated `PostMeta` and `Options` `getValueAttribute` method to handle behaviour of `unserialize` to return false. Relates to #102 

```
Testing started at 20:02 ...
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from C:\xampp\htdocs\corcel\phpunit.xml



Time: 1.49 seconds, Memory: 8.00Mb

OK (41 tests, 366 assertions)

Process finished with exit code 0
```