### PR TITLE
make post_type fillable for all Post classes

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -30,6 +30,7 @@ class Post extends Model
         'post_content',
         'post_title',
         'post_excerpt',
+        'post_type',
         'to_ping',
         'pinged',
         'post_content_filtered'

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -176,4 +176,11 @@ class PostTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('no_prefix', $post->author->getConnectionName());
     }
+
+    public function testPostTypeIsFillable()
+    {
+        $postType = 'video';
+        $post = new Post(['post_type' => $postType]);
+        $this->assertEquals($postType, $post->post_type);
+    }
 }


### PR DESCRIPTION
post_type is fillable for Post
added Test for adding post type as fillable to Post

```
Testing started at 20:38 ...
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from C:\xampp\htdocs\corcel\phpunit.xml



Time: 1.5 seconds, Memory: 8.00Mb

OK (43 tests, 130 assertions)

Process finished with exit code 0
```