### PR TITLE
Added support for non-corcel relationships

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
         "classmap": [
             "models"
         ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/models"
+        ]
     }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -16,19 +16,39 @@ use Illuminate\Support\Str;
 
 class Model extends Eloquent
 {
-    public function hasMany($related, $foreignKey = null, $localKey = null)
+    /**
+     * @param string $related
+     * @param null   $foreignKey
+     * @param null   $localKey
+     * @param bool   $applyConnection  defaults to true. Set to false if you don't want
+     *                                 the connection of the calling model to be applied to the related model
+     * @return HasMany
+     */
+    public function hasMany($related, $foreignKey = null, $localKey = null, $applyConnection = true)
     {
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related();
-        $instance->setConnection($this->getConnection()->getName());
+
+        if ($applyConnection) {
+            $instance->setConnection($this->getConnection()->getName());
+        }
 
         $localKey = $localKey ?: $this->getKeyName();
 
         return new HasMany($instance->newQuery(), $this, $foreignKey, $localKey);
     }
 
-    public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null)
+    /**
+     * @param string $related
+     * @param null   $foreignKey
+     * @param null   $otherKey
+     * @param null   $relation
+     * @param bool   $applyConnection  defaults to true. Set to false if you don't want
+     *                                 the connection of the calling model to be applied to the related model
+     * @return BelongsTo
+     */
+    public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null, $applyConnection = true)
     {
         if (is_null($relation)) {
             list($current, $caller) = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
@@ -41,7 +61,10 @@ class Model extends Eloquent
         }
 
         $instance = new $related();
-        $instance->setConnection($this->getConnection()->getName());
+
+        if ($applyConnection) {
+            $instance->setConnection($this->getConnection()->getName());
+        }
 
         $query = $instance->newQuery();
 
@@ -50,7 +73,17 @@ class Model extends Eloquent
         return new BelongsTo($query, $this, $foreignKey, $otherKey, $relation);
     }
 
-    public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null)
+    /**
+     * @param string $related
+     * @param null   $table
+     * @param null   $foreignKey
+     * @param null   $otherKey
+     * @param null   $relation
+     * @param bool   $applyConnection  defaults to true. Set to false if you don't want
+     *                                 the connection of the calling model to be applied to the related model
+     * @return BelongsToMany
+     */
+    public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null, $applyConnection = true)
     {
         if (is_null($relation)) {
             $relation = $this->getBelongsToManyCaller();
@@ -59,7 +92,10 @@ class Model extends Eloquent
         $foreignKey = $foreignKey ?: $this->getForeignKey();
 
         $instance = new $related();
-        $instance->setConnection($this->getConnection()->getName());
+
+        if ($applyConnection) {
+            $instance->setConnection($this->getConnection()->getName());
+        }
 
         $otherKey = $otherKey ?: $instance->getForeignKey();
 

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -183,4 +183,19 @@ class PostTest extends PHPUnit_Framework_TestCase
         $post = new Post(['post_type' => $postType]);
         $this->assertEquals($postType, $post->post_type);
     }
+
+    public function testRelationToNonCorcelClasses()
+    {
+        $eloquent = NonCorcelTestModel::find(1);
+        /** @var CorcelTestModel $corcel */
+        $corcel = CorcelTestModel::find(1);
+
+        //can get non corcel models from relation on corcel
+        $this->assertInstanceOf("NonCorcelTestModel", $corcel->eloquent->first());
+        $this->assertEquals($eloquent->id, $corcel->eloquent->first()->id);
+
+        //throws an exception if the connection is set on the related model
+        $this->setExpectedException("Illuminate\\Database\\QueryException");
+        $corcel->eloquentWithConnection->first();
+    }
 }

--- a/tests/config/database.sql
+++ b/tests/config/database.sql
@@ -1311,10 +1311,11 @@ UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `eloquent`;
 
-CREATE TABLE `eloquent` (
-	`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-	`corcel_id` bigint(20) unsigned NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+CREATE TABLE eloquent
+(
+	id INT PRIMARY KEY AUTO_INCREMENT,
+	corcel_id BIGINT NOT NULL
+);
 
 INSERT INTO `eloquent` (`id`, `corcel_id`)
 VALUES (1, 1)

--- a/tests/config/database.sql
+++ b/tests/config/database.sql
@@ -1309,7 +1309,15 @@ VALUES
 /*!40000 ALTER TABLE `wp_users` ENABLE KEYS */;
 UNLOCK TABLES;
 
+DROP TABLE IF EXISTS `eloquent`;
 
+CREATE TABLE `eloquent` (
+	`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	`corcel_id` bigint(20) unsigned NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO `eloquent` (`id`, `corcel_id`)
+VALUES (1, 1)
 
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/tests/models/CorcelTestModel.php
+++ b/tests/models/CorcelTestModel.php
@@ -5,7 +5,7 @@ class CorcelTestModel extends \Corcel\Post
 
     public function eloquent()
     {
-        return $this->hasMany('NonCorcelTestModel', 'id', 'ID', false);
+        return $this->hasMany('NonCorcelTestModel', 'corcel_id', 'ID', false);
     }
 
     public function eloquentWithConnection()

--- a/tests/models/CorcelTestModel.php
+++ b/tests/models/CorcelTestModel.php
@@ -1,0 +1,15 @@
+<?php
+
+class CorcelTestModel extends \Corcel\Post
+{
+
+    public function eloquent()
+    {
+        return $this->hasMany('NonCorcelTestModel', 'id', 'ID', false);
+    }
+
+    public function eloquentWithConnection()
+    {
+        return $this->hasMany('NonCorcelTestModel', 'id', 'ID', true);
+    }
+}

--- a/tests/models/NonCorcelTestModel.php
+++ b/tests/models/NonCorcelTestModel.php
@@ -1,0 +1,12 @@
+<?php
+
+class NonCorcelTestModel extends \Illuminate\Database\Eloquent\Model
+{
+    protected $connection = 'no_prefix';
+    protected $table = 'eloquent';
+
+    public function corcel()
+    {
+        return $this->belongsTo('CorcelTestModel', 'corcel_id', 'ID');
+    }
+}


### PR DESCRIPTION
See #113 for details about this issue. 

This is my suggestion on how to handle it without breaking backwards compatibility, however alternative suggestions are very much appreciated.

To support the tests I have added two new classes that are autoloaded with `autoload-dev` in composer, so you will need to run `composer dumpautoload` to get them. I have also added a new table to the `database.sql` file to hold the non-corcel model (which I've called eloquent). You will need to import that new table into your db before running the tests.