### PR TITLE
remove require autoload.php

### DIFF
--- a/src/Password/PasswordService.php
+++ b/src/Password/PasswordService.php
@@ -4,8 +4,6 @@ namespace Corcel\Password;
 
 use Hautelook\Phpass\PasswordHash;
 
-require_once(__DIR__ . "/../../vendor/autoload.php");
-
 class PasswordService
 {
     public function __construct()


### PR DESCRIPTION
***copy of #145 but to (and from) correct develop branch***

While implementing the PasswordService into my (Laravel 5) project I got a fatal error:

> Fatal error: main(): Failed opening required '/path/to/project/vendor/jgrossi/corcel/src/Password/../../vendor/autoload.php' (include_path='.:/usr/share/php:') in /path/to/project/vendor/jgrossi/corcel/src/Password/PasswordService.php on line 7

Since Laravel already includes /vendor/autoload.php, it's not needed to do this again.