### PR TITLE
Inverting order in __get() in Post to avoid missing property errors

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -195,8 +195,12 @@ class Post extends Model
      */
     public function __get($key)
     {
+        if ($value = parent::__get($key)) {
+            return $value;
+        }
+
         if (!isset($this->$key)) {
-            if (isset($this->meta()->get()->$key)) {
+            if (isset($this->meta->$key)) {
                 return $this->meta->$key;
             }
         } elseif (isset($this->$key) and empty($this->$key)) {
@@ -228,8 +232,6 @@ class Post extends Model
                 }
             }
         }
-
-        return parent::__get($key);
     }
 
     public function save(array $options = [])


### PR DESCRIPTION
This should fix any problem with something like `Undefined property: App\Post::$var`.

```
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from /home/vagrant/Github/corcel/phpunit.xml

.............................................

Time: 1.18 seconds, Memory: 10.00MB

OK (45 tests, 134 assertions)
```