### PR TITLE
Ensure $post->post_parent does not return null when it is zero

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -195,7 +195,7 @@ class Post extends Model
      */
     public function __get($key)
     {
-        if ($value = parent::__get($key)) {
+        if (($value = parent::__get($key)) !== null) {
             return $value;
         }
 

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -61,7 +61,7 @@ class PostTest extends PHPUnit_Framework_TestCase
         ];
 
         $post = new Post();
-        foreach($values as $k => $v) {
+        foreach ($values as $k => $v) {
             $post->{$k} = $v;
         }
         $post->save();
@@ -69,7 +69,7 @@ class PostTest extends PHPUnit_Framework_TestCase
 
 
         $post = Post::find($postID);
-        foreach($values as $k => $v) {
+        foreach ($values as $k => $v) {
             $this->assertEquals($post->{$k}, $v);
 
             $accessorName = substr($k, strlen('post_'));

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -212,4 +212,16 @@ class PostTest extends PHPUnit_Framework_TestCase
         $post = new Post(['post_type' => $postType]);
         $this->assertEquals($postType, $post->post_type);
     }
+
+    /**
+     * This tests to ensure that when the post_parent is 0, it returns 0 and not null
+     * Ocde in the Post::_get() method only checked if the value was false, and so
+     * wouldn't return values from the model that were false (like 0)
+     */
+    public function testPostParentDoesNotReturnNullWhenItIsZero()
+    {
+        $post = Post::find(1);
+
+        $this->assertNotNull($post->post_parent);
+    }
 }

--- a/tests/config/autoload.php
+++ b/tests/config/autoload.php
@@ -1,7 +1,7 @@
 <?php require __DIR__ . '/../../vendor/autoload.php';
 
 $capsule = \Corcel\Database::connect($params = [
-    'database' => 'corcel',
+    'database' => 'corcel-dev',
     'username' => 'root',
     'password' => '',
     'host' => '127.0.0.1',


### PR DESCRIPTION
_get must only return null if the value from the model is null, not if the value is false.
When post_parent is 0, old code was returning null when it should have returned 0

```
C:\xampp\php\php.exe C:/Users/Matthew/AppData/Local/Temp/ide-phpunit.php --configuration C:\xampp\htdocs\corcel\phpunit.xml
Testing started at 13:16 ...
PHPUnit 4.2.2 by Sebastian Bergmann.

Configuration read from C:\xampp\htdocs\corcel\phpunit.xml



Time: 366 ms, Memory: 10.00MB

OK (49 tests, 146 assertions)

Process finished with exit code 0
```