### PR TITLE
Make sure Post is loaded before trying to fetch its metas

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -200,7 +200,7 @@ class Post extends Model
         }
 
         if (!property_exists($this, $key)) {
-            if (isset($this->meta->$key)) {
+            if (property_exists($this, $this->primaryKey) && isset($this->meta->$key)) {
                 return $this->meta->$key;
             }
         } elseif (isset($this->$key) and empty($this->$key)) {


### PR DESCRIPTION
Fixes issue #162 

Before:
**$ php index.php**
string(74) "select * from `postmeta` where `post_id` is null and `post_id` is not null"
string(52) "select * from `posts` where `posts`.`ID` = ? limit 1"
string(47) "select * from `postmeta` where `post_id` in (?)"

**After:**
$ php index.php
string(52) "select * from `posts` where `posts`.`ID` = ? limit 1"
string(47) "select * from `postmeta` where `post_id` in (?)"