### PR TITLE
Add the "has meta" query condition.

### DIFF
--- a/src/UserBuilder.php
+++ b/src/UserBuilder.php
@@ -25,4 +25,20 @@ class UserBuilder extends Builder
 
         return $this->skip($skip)->take($perPage)->get();
     }
+
+    /**
+     * Add nested meta exists conditions to the query.
+     *
+     * @param string $metaKey
+     * @param string $metaValue
+     * @return UserBuilder|static
+     */
+    public function hasMeta($metaKey, $metaValue)
+    {
+        return $this->whereHas('meta', function($query) use($metaKey, $metaValue) {
+            $query->where('meta_key', $metaKey)
+                ->where('meta_value', $metaValue)
+            ;
+        });
+    }
 }

--- a/src/UserBuilder.php
+++ b/src/UserBuilder.php
@@ -35,7 +35,7 @@ class UserBuilder extends Builder
      */
     public function hasMeta($metaKey, $metaValue)
     {
-        return $this->whereHas('meta', function($query) use($metaKey, $metaValue) {
+        return $this->whereHas('meta', function ($query) use ($metaKey, $metaValue) {
             $query->where('meta_key', $metaKey)
                 ->where('meta_value', $metaValue)
             ;


### PR DESCRIPTION
Hi guys!

I added the `hasMeta` method in `UserBuild` because resulted in error getting the user logged in by remember token.
This simply adds nested `whereHas` by meta relationship, for verify if it exists.

Example:
```php
$this->createModel()->newQuery()
    ->whereId($identifier)
    ->hasMeta('remember_token', $token)
    ->first()
;
```

Like this:
```php
$this->createModel()->newQuery()
    ->whereId($identifier)
    ->whereHas('meta', function($query) use($token) {
        $query->where('meta_key', 'remember_token')
            ->where('meta_value', $token)
        ;
    })
    ->first()
;
```

If you have better solution, ignore this please! :smiley:
Thanks!

Sorry for bad english :confused: