### PR TITLE
Fix for #300 - undefined methods while converting model to array and JSON

### DIFF
--- a/src/Traits/AliasesTrait.php
+++ b/src/Traits/AliasesTrait.php
@@ -37,7 +37,7 @@ trait AliasesTrait
 
     /**
      * Get alias value from mutator or directly from attribute
-     * 
+     *
      * @param  string $key
      * @param  mixed $value
      * @return mixed

--- a/src/Traits/AliasesTrait.php
+++ b/src/Traits/AliasesTrait.php
@@ -36,6 +36,22 @@ trait AliasesTrait
     }
 
     /**
+     * Get alias value from mutator or directly from attribute
+     * 
+     * @param  string $key
+     * @param  mixed $value
+     * @return mixed
+     */
+    public function mutateAttribute($key, $value)
+    {
+        if ($this->hasGetMutator($key)) {
+            return parent::mutateAttribute($key, $value);
+        }
+
+        return $this->getAttribute($key);
+    }
+
+    /**
      * @return array
      */
     public static function getAliases()

--- a/tests/Unit/Traits/AliasesTraitTest.php
+++ b/tests/Unit/Traits/AliasesTraitTest.php
@@ -3,6 +3,7 @@
 namespace Corcel\Tests\Unit\Traits;
 
 use Corcel\Model\Attachment;
+use Corcel\Model\Post;
 
 /**
  * Class AliasesTraitTest
@@ -25,5 +26,27 @@ class AliasesTraitTest extends \Corcel\Tests\TestCase
         $this->assertNotNull($attachment->status);
         $this->assertNotNull($attachment->content);
         $this->assertNull($attachment->wrong_property);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_aliases_after_to_array()
+    {
+        $post = factory(Post::class)->create([
+            'post_title' => 'Test title',
+        ]);
+        $array = $post->toArray();
+
+        // default accessor is working
+        $this->assertEquals('Uncategorized', $array['main_category']);
+        // default db value is working
+        $this->assertEquals('Test title', $array['post_title']);
+        // alias is in array
+        $this->assertArrayHasKey('title', $array);
+        // unknown keys are not in array
+        $this->assertArrayNotHasKey('wrong_key', $array);
+        // alias and db value are the same
+        $this->assertEquals($array['post_title'], $array['title']);
     }
 }


### PR DESCRIPTION
Fixed #300. Added method which override default `mutateAttribute` and test case. On current release this test throws error, with this fix all passed.