### PR TITLE
Post search feature

### DIFF
--- a/src/Model/Builder/PostBuilder.php
+++ b/src/Model/Builder/PostBuilder.php
@@ -83,9 +83,9 @@ class PostBuilder extends Builder
 
         $terms = is_string($term) ? explode(' ', $term) : $term;
         
-        $terms = collect($terms)->map(function($term) {
+        $terms = collect($terms)->map(function ($term) {
             return trim(str_replace('%', '', $term));
-        })->filter()->map(function($term) {
+        })->filter()->map(function ($term) {
             return '%' . $term . '%';
         });
 
@@ -93,8 +93,8 @@ class PostBuilder extends Builder
             return $this;
         }
 
-        return $this->where(function($query) use ($terms) {
-            $terms->each(function($term) use ($query) {
+        return $this->where(function ($query) use ($terms) {
+            $terms->each(function ($term) use ($query) {
                 $query->orWhere('post_title', 'like', $term)
                     ->orWhere('post_excerpt', 'like', $term)
                     ->orWhere('post_content', 'like', $term);

--- a/src/Model/Builder/PostBuilder.php
+++ b/src/Model/Builder/PostBuilder.php
@@ -72,7 +72,7 @@ class PostBuilder extends Builder
     }
 
     /**
-     * @param bool|string|array $term
+     * @param mixed $term
      * @return PostBuilder
      */
     public function search($term = false)

--- a/src/Model/Builder/PostBuilder.php
+++ b/src/Model/Builder/PostBuilder.php
@@ -70,4 +70,35 @@ class PostBuilder extends Builder
                 });
         });
     }
+
+    /**
+     * @param bool|string|array $term
+     * @return PostBuilder
+     */
+    public function search($term = false)
+    {
+        if (empty($term)) {
+            return $this;
+        }
+
+        $terms = is_string($term) ? explode(' ', $term) : $term;
+        
+        $terms = collect($terms)->map(function($term) {
+            return trim(str_replace('%', '', $term));
+        })->filter()->map(function($term) {
+            return '%' . $term . '%';
+        });
+
+        if ($terms->isEmpty()) {
+            return $this;
+        }
+
+        return $this->where(function($query) use ($terms) {
+            $terms->each(function($term) use ($query) {
+                $query->orWhere('post_title', 'like', $term)
+                    ->orWhere('post_excerpt', 'like', $term)
+                    ->orWhere('post_content', 'like', $term);
+            });
+        });
+    }
 }

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -563,6 +563,35 @@ class PostTest extends \Corcel\Tests\TestCase
     }
 
     /**
+     * @test
+     */
+    public function its_search_generate_correct_query() {
+        $emptyWord = Post::search();
+        $singleWord = Post::search('foo');
+        $multipleWord = Post::search('foo bar');
+        $multipleWordArray = Post::search(['foo', 'bar']);
+
+        $expectedEmptyWordQuery = 'select * from "wp_posts"';
+        $expectedSingleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+        $expectedMultipleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ? or "post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+
+        $expectedSingleWordBindings = ['%foo%', '%foo%', '%foo%'];
+        $expectedMultipleWordBindings = ['%foo%', '%foo%', '%foo%', '%bar%', '%bar%', '%bar%'];
+
+        $this->assertEquals($emptyWord->toSql(), $expectedEmptyWordQuery);
+        $this->assertSame($emptyWord->getBindings(), []);
+
+        $this->assertEquals($singleWord->toSql(), $expectedSingleWordQuery);
+        $this->assertSame($singleWord->getBindings(), $expectedSingleWordBindings);
+
+        $this->assertEquals($multipleWord->toSql(), $expectedMultipleWordQuery);
+        $this->assertSame($multipleWord->getBindings(), $expectedMultipleWordBindings);
+
+        $this->assertEquals($multipleWordArray->toSql(), $expectedMultipleWordQuery);
+        $this->assertSame($multipleWordArray->getBindings(), $expectedMultipleWordBindings);
+    }
+
+    /**
      *
      * @return Post
      */

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -602,8 +602,6 @@ class PostTest extends \Corcel\Tests\TestCase
 
         $this->assertEquals($expectedMultipleWordQuery, $multipleWord->toSql());
         $this->assertSame($expectedMultipleWordBindings, $multipleWord->getBindings());
-
-
     }
 
     /**
@@ -623,7 +621,8 @@ class PostTest extends \Corcel\Tests\TestCase
     /**
      * @test
      */
-    public function its_search_for_different_post_types_is_correct() {
+    public function its_search_for_different_post_types_is_correct()
+    {
         $singleWord = Page::search('foo');
         $multipleWord = Page::search('foo bar');
 

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -565,30 +565,73 @@ class PostTest extends \Corcel\Tests\TestCase
     /**
      * @test
      */
-    public function its_search_generate_correct_query() {
+    public function its_search_has_correct_empty_word_query()
+    {
         $emptyWord = Post::search();
-        $singleWord = Post::search('foo');
-        $multipleWord = Post::search('foo bar');
-        $multipleWordArray = Post::search(['foo', 'bar']);
 
         $expectedEmptyWordQuery = 'select * from "wp_posts"';
-        $expectedSingleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
-        $expectedMultipleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ? or "post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+        $expectedEmptyWordBindings = [];
 
+        $this->assertEquals($expectedEmptyWordQuery, $emptyWord->toSql());
+        $this->assertSame($expectedEmptyWordBindings, $emptyWord->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function its_search_has_correct_single_word_query()
+    {
+        $singleWord = Post::search('foo');
+
+        $expectedSingleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
         $expectedSingleWordBindings = ['%foo%', '%foo%', '%foo%'];
+
+        $this->assertEquals($expectedSingleWordQuery, $singleWord->toSql());
+        $this->assertSame($expectedSingleWordBindings, $singleWord->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function its_search_has_correct_multiple_word_query()
+    {
+        $multipleWord = Post::search('foo bar');
+
+        $expectedMultipleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ? or "post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
         $expectedMultipleWordBindings = ['%foo%', '%foo%', '%foo%', '%bar%', '%bar%', '%bar%'];
 
-        $this->assertEquals($emptyWord->toSql(), $expectedEmptyWordQuery);
-        $this->assertSame($emptyWord->getBindings(), []);
+        $this->assertEquals($expectedMultipleWordQuery, $multipleWord->toSql());
+        $this->assertSame($expectedMultipleWordBindings, $multipleWord->getBindings());
 
-        $this->assertEquals($singleWord->toSql(), $expectedSingleWordQuery);
-        $this->assertSame($singleWord->getBindings(), $expectedSingleWordBindings);
 
-        $this->assertEquals($multipleWord->toSql(), $expectedMultipleWordQuery);
-        $this->assertSame($multipleWord->getBindings(), $expectedMultipleWordBindings);
+    }
 
-        $this->assertEquals($multipleWordArray->toSql(), $expectedMultipleWordQuery);
-        $this->assertSame($multipleWordArray->getBindings(), $expectedMultipleWordBindings);
+    /**
+     * @test
+     */
+    public function its_search_has_correct_multiple_word_in_array_query()
+    {
+        $multipleWordArray = Post::search(['foo', 'bar']);
+
+        $expectedMultipleWordQuery = 'select * from "wp_posts" where ("post_title" like ? or "post_excerpt" like ? or "post_content" like ? or "post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+        $expectedMultipleWordBindings = ['%foo%', '%foo%', '%foo%', '%bar%', '%bar%', '%bar%'];
+
+        $this->assertEquals($expectedMultipleWordQuery, $multipleWordArray->toSql());
+        $this->assertSame($expectedMultipleWordBindings, $multipleWordArray->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function its_search_for_different_post_types_is_correct() {
+        $singleWord = Page::search('foo');
+        $multipleWord = Page::search('foo bar');
+
+        $expectedSingleWordQuery = 'select * from "wp_posts" where "post_type" = ? and ("post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+        $expectedMultipleWordQuery = 'select * from "wp_posts" where "post_type" = ? and ("post_title" like ? or "post_excerpt" like ? or "post_content" like ? or "post_title" like ? or "post_excerpt" like ? or "post_content" like ?)';
+
+        $this->assertEquals($expectedSingleWordQuery, $singleWord->toSql());
+        $this->assertEquals($expectedMultipleWordQuery, $multipleWord->toSql());
     }
 
     /**


### PR DESCRIPTION
This PR is related to #269. Wordpress-like way for searching `wp_posts` table. Features that this PR does not include:

- rejecting words (for example `foo -bar` which means search posts, where sentences has foo but has not bar)
- sorting by accuracy (for example posts with `%foo bar%` in title should have higher position than posts with `%foo%` in content)

This is very simple attempt that allows to search by single or multiple words. We can pass no parameter, string or array of strings. Strings are exploded by space, so if you really want to search by sentences you need to put sentence in array.

### Usage

- `Post::search()->get()`, `Post::search(false)->get()`, `Post::search(null)->get()`, `Post::search([''])->get()`, `Post::search('%     %')->get()` - get all posts (if parameter is empty after removing percents from words and white-space trim then skip search)
- `Post::search('lorem')->get()` - get all posts where title, excerpt or content has word `lorem`
- `Post::search('lorem ipsum')->get()` - get all posts where title, excerpt or content has word `lorem` **or** `ipsum`
- `Post::search(['lorem', 'ipsum'])->get()` - works as above
- `Post::search(['lorem ipsum'])->get()` - get all posts where title, excerpt or content has **sentence** `lorem ipsum`

### Example in Laravel

#### Url:
`http://example.org/?s=lorem`

#### Route:
`Route::get('/', 'BarController@index');`

#### Controller:
```php
namespace Foo;

use Illuminate\Http\Request;
use Corcel\Model\Post;

class BarController {
	public function index( Request $request ) {
		$s = $request->get( 's' );

		$posts = Post::search( $s )->paginate( 10 );

		return view( 'example', [
			'posts' => $posts,
		] );
	}
}
```

For now this will not pass tests, because of #327. After merging that PR everything should work well :blush: