### PR TITLE
Allow using default meta classes in extended models

### DIFF
--- a/src/Traits/HasMetaFields.php
+++ b/src/Traits/HasMetaFields.php
@@ -42,7 +42,7 @@ trait HasMetaFields
     protected function getMetaClass()
     {
         foreach ($this->builtInClasses as $model => $meta) {
-            if ($this instanceOf $model) {
+            if ($this instanceof $model) {
                 return $meta;
             }
         }
@@ -61,7 +61,7 @@ trait HasMetaFields
     protected function getMetaForeignKey()
     {
         foreach ($this->builtInClasses as $model => $meta) {
-            if ($this instanceOf $model) {
+            if ($this instanceof $model) {
                 $basename = class_basename($model);
 
                 return sprintf('%s_id', strtolower($basename));

--- a/tests/Unit/Model/UserTest.php
+++ b/tests/Unit/Model/UserTest.php
@@ -5,6 +5,7 @@ namespace Corcel\Tests\Unit\Model;
 use Carbon\Carbon;
 use Corcel\Model\Collection\MetaCollection;
 use Corcel\Model\User;
+use Corcel\Model\Post;
 
 /**
  * Class UserTest
@@ -195,4 +196,28 @@ class UserTest extends \Corcel\Tests\TestCase
 
         $this->assertEquals('//secure.gravatar.com/avatar/?d=mm', $user->avatar);
     }
+
+    /**
+     * @test
+     */
+     public function it_children_has_correct_meta_relation()
+    {
+        $post = factory(Post::class)->create();
+        $post->createMeta('foo', 'bar');
+        $user = factory(User::class)->create();
+        $user->createMeta('bar', 'foo');
+
+        $customer = new Customer();
+        $customer->ID = $user->ID;
+
+        // post ID and customer ID are same
+        $this->assertEquals($post->ID, $customer->ID);
+        $this->assertEquals('foo', $customer->meta->bar);
+        $this->assertNull($customer->meta->foo);
+    }
+}
+
+class Customer extends User
+{
+    //
 }

--- a/tests/Unit/Model/UserTest.php
+++ b/tests/Unit/Model/UserTest.php
@@ -200,7 +200,7 @@ class UserTest extends \Corcel\Tests\TestCase
     /**
      * @test
      */
-     public function it_children_has_correct_meta_relation()
+    public function it_children_has_correct_meta_relation()
     {
         $post = factory(Post::class)->create();
         $post->createMeta('foo', 'bar');


### PR DESCRIPTION
Fixes #307. This is #308 PR with fix. Still this need more tests, so please do not merge.

Default fallback to `PostMeta` has been removed. Now classes which not extends one of the base Models (Comment, Post, Term or User) will throw `UnexpectedValueException` .

I think that this should allow defining custom Meta classes for custom Models (for example by defining `$metaClass` in Model). What do you think?