### PR TITLE
Make possible to create new user role

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,23 @@ $user = User::find(1);
 echo $user->user_login;
 ```
 
+### Creating Roles
+
+You can also create a new role based on a pre-existent one. For example, to create a role `foo` based on the `editor` role:
+
+```php
+$manager = new RoleManager();
+$role = $manager->from('editor')->create('foo', [
+    'edit_pages' => false,
+    'edit_others_pages' => false,
+]);
+
+echo $role['name'];
+var_dump($role['capabilities']); // array
+```
+
+The new capabilities array you send in the `create()` method will override the `editor` capabilities. You can also add new capabilities as well.
+
 ## <a id="auth"></a>Authentication
 
 ### Using Laravel

--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -73,22 +73,6 @@ class Option extends Model
     }
 
     /**
-     * @param string $key
-     * @param mixed $value
-     * @return bool
-     */
-    public static function save($key, $value)
-    {
-        $where = ['option_name' => $key];
-
-        return static::query()->updateOrInsert($where, [
-            'option_value' => is_array($value) ?
-                serialize($value) :
-                $value,
-        ]);
-    }
-
-    /**
      * @param string $name
      * @return mixed
      */

--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -62,13 +62,29 @@ class Option extends Model
     /**
      * @param string $key
      * @param mixed $value
-     * @return Option
+     * @return Option|\Illuminate\Database\Eloquent\Model
      */
     public static function add($key, $value)
     {
-        return static::create([
+        return static::query()->create([
             'option_name' => $key,
             'option_value' => is_array($value) ? serialize($value) : $value,
+        ]);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @return bool
+     */
+    public static function save($key, $value)
+    {
+        $where = ['option_name' => $key];
+
+        return static::query()->updateOrInsert($where, [
+            'option_value' => is_array($value) ?
+                serialize($value) :
+                $value,
         ]);
     }
 

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -5,6 +5,12 @@ namespace Corcel\Services;
 use Corcel\Model\Option;
 use Illuminate\Support\Arr;
 
+/**
+ * Class RoleManager
+ *
+ * @package Corcel\Services
+ * @author Junior Grossi <juniorgro@gmail.com>
+ */
 class RoleManager
 {
     /**

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -62,4 +62,3 @@ class RoleManager
         return $role;
     }
 }
-

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -44,13 +44,16 @@ class RoleManager
     {
         $key = str_slug($name, '_');
 
-        Option::save($key, array_merge(
-            $this->capabilities, $capabilities
-        ));
+        $this->option[$key] = $role = [
+            'name' => $name,
+            'capabilities' => array_merge($this->capabilities, $capabilities),
+        ];
 
-        return Option::get(
-            Arr::get(Option::get($this->optionKey), $name)
-        );
+        Option::query()->update(['option_name' => $key], [
+            'option_value' => serialize($this->option),
+        ]);
+
+        return $role;
     }
 }
 

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
  *
  * @package Corcel\Services
  * @author Junior Grossi <juniorgro@gmail.com>
+ * @todo Update, delete and list roles
  */
 class RoleManager
 {
@@ -57,7 +58,7 @@ class RoleManager
     {
         $key = str_slug($name, '_');
 
-        $this->option[$key] = $role = [
+        $this->option[][$key] = $role = [
             'name' => $name,
             'capabilities' => array_merge($this->capabilities, $capabilities),
         ];

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -34,7 +34,7 @@ class RoleManager
      */
     public function __construct()
     {
-        $this->option = Option::get($this->optionKey);
+        $this->option = Option::get($this->optionKey); // TODO set this to the Option model
     }
 
     /**
@@ -63,10 +63,13 @@ class RoleManager
             'capabilities' => array_merge($this->capabilities, $capabilities),
         ];
 
-        Option::query()->update(['option_name' => $this->optionKey], [
-            'option_value' => serialize($this->option),
-        ]);
+        $option = Option::query()
+            ->where(['option_name' => $this->optionKey])
+            ->first();
 
-        return $role;
+        $option->option_value = serialize($this->option);
+        $result = $option->save();
+
+        return $result ? $role : null;
     }
 }

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -29,12 +29,19 @@ class RoleManager
     protected $capabilities = [];
 
     /**
+     * Create a new RoleManager instance
+     */
+    public function __construct()
+    {
+        $this->option = Option::get($this->optionKey);
+    }
+
+    /**
      * @param string $role
      * @return $this
      */
     public function from($role)
     {
-        $this->option = Option::get($this->optionKey);
         $role = Arr::get($this->option, $role);
         $this->capabilities = Arr::get($role, 'capabilities');
 

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -58,12 +58,12 @@ class RoleManager
     {
         $key = str_slug($name, '_');
 
-        $this->option[][$key] = $role = [
+        $this->option[$key] = $role = [
             'name' => $name,
             'capabilities' => array_merge($this->capabilities, $capabilities),
         ];
 
-        Option::query()->update(['option_name' => $key], [
+        Option::query()->update(['option_name' => $this->optionKey], [
             'option_value' => serialize($this->option),
         ]);
 

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -39,12 +39,22 @@ class RoleManager
 
     /**
      * @param string $role
+     * @return array
+     */
+    public function get($role)
+    {
+        return Arr::get($this->option, $role);
+    }
+
+    /**
+     * @param string $role
      * @return $this
      */
     public function from($role)
     {
-        $role = Arr::get($this->option, $role);
-        $this->capabilities = Arr::get($role, 'capabilities');
+        $this->capabilities = Arr::get(
+            $this->get($role), 'capabilities'
+        );
 
         return $this;
     }

--- a/src/Services/RoleManager.php
+++ b/src/Services/RoleManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Corcel\Services;
+
+use Corcel\Model\Option;
+use Illuminate\Support\Arr;
+
+class RoleManager
+{
+    /**
+     * @var string
+     */
+    protected $optionKey = 'wp_user_roles';
+
+    /**
+     * @var array
+     */
+    protected $option = [];
+
+    /**
+     * @var array
+     */
+    protected $capabilities = [];
+
+    /**
+     * @param string $role
+     * @return $this
+     */
+    public function from($role)
+    {
+        $this->option = Option::get($this->optionKey);
+        $role = Arr::get($this->option, $role);
+        $this->capabilities = Arr::get($role, 'capabilities');
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param array $capabilities
+     * @return array
+     */
+    public function create($name, array $capabilities)
+    {
+        $key = str_slug($name, '_');
+
+        Option::save($key, array_merge(
+            $this->capabilities, $capabilities
+        ));
+
+        return Option::get(
+            Arr::get(Option::get($this->optionKey), $name)
+        );
+    }
+}
+

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -36,7 +36,7 @@ class RoleManagerTest extends TestCase
 
         $this->assertFalse($role['capabilities']['edit_pages']);
         $this->assertFalse($role['capabilities']['edit_others_pages']);
-        $this->assertRole('foo', $role);
+        $this->assertRoleEquals('foo', $role);
     }
 
     /**
@@ -52,7 +52,7 @@ class RoleManagerTest extends TestCase
         $this->assertTrue($role['capabilities']['edit_pages']);
         $this->assertTrue($role['capabilities']['edit_others_pages']);
         $this->assertCount(2, $role['capabilities']);
-        $this->assertRole('foo', $role);
+        $this->assertRoleEquals('foo', $role);
     }
 
     /**
@@ -69,7 +69,7 @@ class RoleManagerTest extends TestCase
      * @param string $key
      * @param array $role
      */
-    private function assertRole($key, array $role)
+    private function assertRoleEquals($key, array $role)
     {
         $roles = Option::get('wp_user_roles');
 

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -15,21 +15,42 @@ use Corcel\Tests\TestCase;
 class RoleManagerTest extends TestCase
 {
     /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->insertDefaultRoles();
+    }
+
+    /**
      * @test
      */
     public function it_creates_a_new_role_based_on_a_previous_one()
     {
-        $this->insertDefaultRoles();
-
-        $manager = new RoleManager();
-
-        $role = $manager->from('editor')->create('foo', [
-            'edit_pages' => false,
-            'edit_others_pages' => false,
-        ]);
+        $role = (new RoleManager())->from('editor')
+            ->create('foo', [
+                'edit_pages' => false,
+                'edit_others_pages' => false,
+            ]);
 
         $this->assertFalse($role['capabilities']['edit_pages']);
         $this->assertFalse($role['capabilities']['edit_others_pages']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_new_role_without_setting_from()
+    {
+        $role = (new RoleManager())->create('foo', [
+            'edit_pages' => true,
+            'edit_others_pages' => true,
+        ]);
+
+        $this->assertTrue($role['capabilities']['edit_pages']);
+        $this->assertTrue($role['capabilities']['edit_others_pages']);
+        $this->assertCount(2, $role['capabilities']);
     }
 
     /**

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Corcel\Tests\Services;
+
+use Corcel\Model\Option;
+use Corcel\Services\RoleManager;
+use Corcel\Tests\TestCase;
+
+class RoleManagerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_a_new_role_based_on_a_previous_one()
+    {
+        $this->insertDefaultRoles();
+
+        $manager = new RoleManager();
+
+        $role = $manager->from('editor')->create('foo', [
+            'edit_pages' => false,
+            'edit_others_pages' => false,
+        ])->get('foo');
+
+        $this->assertFalse($role['capabilities']['edit_pages']);
+        $this->assertFalse($role['capabilities']['edit_others_pages']);
+    }
+
+    /**
+     * @return Option
+     */
+    private function insertDefaultRoles()
+    {
+        $roles = unserialize('a:5:{s:13:"administrator";a:2:{s:4:"name";s:13:"Administrator";s:12:"capabilities";a:61:{s:13:"switch_themes";b:1;s:11:"edit_themes";b:1;s:16:"activate_plugins";b:1;s:12:"edit_plugins";b:1;s:10:"edit_users";b:1;s:10:"edit_files";b:1;s:14:"manage_options";b:1;s:17:"moderate_comments";b:1;s:17:"manage_categories";b:1;s:12:"manage_links";b:1;s:12:"upload_files";b:1;s:6:"import";b:1;s:15:"unfiltered_html";b:1;s:10:"edit_posts";b:1;s:17:"edit_others_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:10:"edit_pages";b:1;s:4:"read";b:1;s:8:"level_10";b:1;s:7:"level_9";b:1;s:7:"level_8";b:1;s:7:"level_7";b:1;s:7:"level_6";b:1;s:7:"level_5";b:1;s:7:"level_4";b:1;s:7:"level_3";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:17:"edit_others_pages";b:1;s:20:"edit_published_pages";b:1;s:13:"publish_pages";b:1;s:12:"delete_pages";b:1;s:19:"delete_others_pages";b:1;s:22:"delete_published_pages";b:1;s:12:"delete_posts";b:1;s:19:"delete_others_posts";b:1;s:22:"delete_published_posts";b:1;s:20:"delete_private_posts";b:1;s:18:"edit_private_posts";b:1;s:18:"read_private_posts";b:1;s:20:"delete_private_pages";b:1;s:18:"edit_private_pages";b:1;s:18:"read_private_pages";b:1;s:12:"delete_users";b:1;s:12:"create_users";b:1;s:17:"unfiltered_upload";b:1;s:14:"edit_dashboard";b:1;s:14:"update_plugins";b:1;s:14:"delete_plugins";b:1;s:15:"install_plugins";b:1;s:13:"update_themes";b:1;s:14:"install_themes";b:1;s:11:"update_core";b:1;s:10:"list_users";b:1;s:12:"remove_users";b:1;s:13:"promote_users";b:1;s:18:"edit_theme_options";b:1;s:13:"delete_themes";b:1;s:6:"export";b:1;}}s:6:"editor";a:2:{s:4:"name";s:6:"Editor";s:12:"capabilities";a:34:{s:17:"moderate_comments";b:1;s:17:"manage_categories";b:1;s:12:"manage_links";b:1;s:12:"upload_files";b:1;s:15:"unfiltered_html";b:1;s:10:"edit_posts";b:1;s:17:"edit_others_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:10:"edit_pages";b:1;s:4:"read";b:1;s:7:"level_7";b:1;s:7:"level_6";b:1;s:7:"level_5";b:1;s:7:"level_4";b:1;s:7:"level_3";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:17:"edit_others_pages";b:1;s:20:"edit_published_pages";b:1;s:13:"publish_pages";b:1;s:12:"delete_pages";b:1;s:19:"delete_others_pages";b:1;s:22:"delete_published_pages";b:1;s:12:"delete_posts";b:1;s:19:"delete_others_posts";b:1;s:22:"delete_published_posts";b:1;s:20:"delete_private_posts";b:1;s:18:"edit_private_posts";b:1;s:18:"read_private_posts";b:1;s:20:"delete_private_pages";b:1;s:18:"edit_private_pages";b:1;s:18:"read_private_pages";b:1;}}s:6:"author";a:2:{s:4:"name";s:6:"Author";s:12:"capabilities";a:10:{s:12:"upload_files";b:1;s:10:"edit_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:4:"read";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:12:"delete_posts";b:1;s:22:"delete_published_posts";b:1;}}s:11:"contributor";a:2:{s:4:"name";s:11:"Contributor";s:12:"capabilities";a:5:{s:10:"edit_posts";b:1;s:4:"read";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:12:"delete_posts";b:1;}}s:10:"subscriber";a:2:{s:4:"name";s:10:"Subscriber";s:12:"capabilities";a:2:{s:4:"read";b:1;s:7:"level_0";b:1;}}}');
+
+        return Option::add('wp_user_roles', $roles);
+    }
+}

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -6,6 +6,12 @@ use Corcel\Model\Option;
 use Corcel\Services\RoleManager;
 use Corcel\Tests\TestCase;
 
+/**
+ * Class RoleManagerTest
+ *
+ * @package Corcel\Tests\Services
+ * @author Junior Grossi <juniorgro@gmail.com>
+ */
 class RoleManagerTest extends TestCase
 {
     /**

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -20,7 +20,7 @@ class RoleManagerTest extends TestCase
         $role = $manager->from('editor')->create('foo', [
             'edit_pages' => false,
             'edit_others_pages' => false,
-        ])->get('foo');
+        ]);
 
         $this->assertFalse($role['capabilities']['edit_pages']);
         $this->assertFalse($role['capabilities']['edit_others_pages']);

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -36,6 +36,7 @@ class RoleManagerTest extends TestCase
 
         $this->assertFalse($role['capabilities']['edit_pages']);
         $this->assertFalse($role['capabilities']['edit_others_pages']);
+        $this->assertRole('foo', $role);
     }
 
     /**
@@ -51,6 +52,7 @@ class RoleManagerTest extends TestCase
         $this->assertTrue($role['capabilities']['edit_pages']);
         $this->assertTrue($role['capabilities']['edit_others_pages']);
         $this->assertCount(2, $role['capabilities']);
+        $this->assertRole('foo', $role);
     }
 
     /**
@@ -61,5 +63,16 @@ class RoleManagerTest extends TestCase
         $roles = unserialize('a:5:{s:13:"administrator";a:2:{s:4:"name";s:13:"Administrator";s:12:"capabilities";a:61:{s:13:"switch_themes";b:1;s:11:"edit_themes";b:1;s:16:"activate_plugins";b:1;s:12:"edit_plugins";b:1;s:10:"edit_users";b:1;s:10:"edit_files";b:1;s:14:"manage_options";b:1;s:17:"moderate_comments";b:1;s:17:"manage_categories";b:1;s:12:"manage_links";b:1;s:12:"upload_files";b:1;s:6:"import";b:1;s:15:"unfiltered_html";b:1;s:10:"edit_posts";b:1;s:17:"edit_others_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:10:"edit_pages";b:1;s:4:"read";b:1;s:8:"level_10";b:1;s:7:"level_9";b:1;s:7:"level_8";b:1;s:7:"level_7";b:1;s:7:"level_6";b:1;s:7:"level_5";b:1;s:7:"level_4";b:1;s:7:"level_3";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:17:"edit_others_pages";b:1;s:20:"edit_published_pages";b:1;s:13:"publish_pages";b:1;s:12:"delete_pages";b:1;s:19:"delete_others_pages";b:1;s:22:"delete_published_pages";b:1;s:12:"delete_posts";b:1;s:19:"delete_others_posts";b:1;s:22:"delete_published_posts";b:1;s:20:"delete_private_posts";b:1;s:18:"edit_private_posts";b:1;s:18:"read_private_posts";b:1;s:20:"delete_private_pages";b:1;s:18:"edit_private_pages";b:1;s:18:"read_private_pages";b:1;s:12:"delete_users";b:1;s:12:"create_users";b:1;s:17:"unfiltered_upload";b:1;s:14:"edit_dashboard";b:1;s:14:"update_plugins";b:1;s:14:"delete_plugins";b:1;s:15:"install_plugins";b:1;s:13:"update_themes";b:1;s:14:"install_themes";b:1;s:11:"update_core";b:1;s:10:"list_users";b:1;s:12:"remove_users";b:1;s:13:"promote_users";b:1;s:18:"edit_theme_options";b:1;s:13:"delete_themes";b:1;s:6:"export";b:1;}}s:6:"editor";a:2:{s:4:"name";s:6:"Editor";s:12:"capabilities";a:34:{s:17:"moderate_comments";b:1;s:17:"manage_categories";b:1;s:12:"manage_links";b:1;s:12:"upload_files";b:1;s:15:"unfiltered_html";b:1;s:10:"edit_posts";b:1;s:17:"edit_others_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:10:"edit_pages";b:1;s:4:"read";b:1;s:7:"level_7";b:1;s:7:"level_6";b:1;s:7:"level_5";b:1;s:7:"level_4";b:1;s:7:"level_3";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:17:"edit_others_pages";b:1;s:20:"edit_published_pages";b:1;s:13:"publish_pages";b:1;s:12:"delete_pages";b:1;s:19:"delete_others_pages";b:1;s:22:"delete_published_pages";b:1;s:12:"delete_posts";b:1;s:19:"delete_others_posts";b:1;s:22:"delete_published_posts";b:1;s:20:"delete_private_posts";b:1;s:18:"edit_private_posts";b:1;s:18:"read_private_posts";b:1;s:20:"delete_private_pages";b:1;s:18:"edit_private_pages";b:1;s:18:"read_private_pages";b:1;}}s:6:"author";a:2:{s:4:"name";s:6:"Author";s:12:"capabilities";a:10:{s:12:"upload_files";b:1;s:10:"edit_posts";b:1;s:20:"edit_published_posts";b:1;s:13:"publish_posts";b:1;s:4:"read";b:1;s:7:"level_2";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:12:"delete_posts";b:1;s:22:"delete_published_posts";b:1;}}s:11:"contributor";a:2:{s:4:"name";s:11:"Contributor";s:12:"capabilities";a:5:{s:10:"edit_posts";b:1;s:4:"read";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:12:"delete_posts";b:1;}}s:10:"subscriber";a:2:{s:4:"name";s:10:"Subscriber";s:12:"capabilities";a:2:{s:4:"read";b:1;s:7:"level_0";b:1;}}}');
 
         return Option::add('wp_user_roles', $roles);
+    }
+
+    /**
+     * @param string $key
+     * @param array $role
+     */
+    private function assertRole($key, array $role)
+    {
+        $roles = Option::get('wp_user_roles');
+
+        $this->assertEquals($roles[$key], $role);
     }
 }

--- a/tests/Unit/Services/RoleManagerTest.php
+++ b/tests/Unit/Services/RoleManagerTest.php
@@ -28,11 +28,13 @@ class RoleManagerTest extends TestCase
      */
     public function it_creates_a_new_role_based_on_a_previous_one()
     {
-        $role = (new RoleManager())->from('editor')
+        (new RoleManager)->from('editor')
             ->create('foo', [
                 'edit_pages' => false,
                 'edit_others_pages' => false,
             ]);
+
+        $role = (new RoleManager)->get('foo');
 
         $this->assertFalse($role['capabilities']['edit_pages']);
         $this->assertFalse($role['capabilities']['edit_others_pages']);
@@ -44,10 +46,12 @@ class RoleManagerTest extends TestCase
      */
     public function it_can_create_a_new_role_without_setting_from()
     {
-        $role = (new RoleManager())->create('foo', [
+        (new RoleManager)->create('foo', [
             'edit_pages' => true,
             'edit_others_pages' => true,
         ]);
+
+        $role = (new RoleManager)->get('foo');
 
         $this->assertTrue($role['capabilities']['edit_pages']);
         $this->assertTrue($role['capabilities']['edit_others_pages']);


### PR DESCRIPTION
This fixes #349. Basically:

```php
$role = (new RoleManager())->from('editor')
    ->create('foo', [
        'edit_pages' => false,
        'edit_others_pages' => false,
    ]);
```

It creates a new `foo` role based on `editor` overriding some capabilities, in this case: `edit_pages` and `edit_others_pages`.

This is going to be merged on `2.5` but if everything is ok it's gonna be merged into `2.4`, `2.3`, `2.2` and `2.1` as well.
