### PR TITLE
Added the getByPath method to Post model.

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -398,6 +398,69 @@ class Post extends Model
     }
 
     /**
+     * Retrieves a post (usually pages) given its path.
+     *
+     * @param string $page_path Page path.
+     * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
+     * @return \Corcel\Model\Post|null \Corcel\Model\Post on success, or null on failure.
+     */
+    public static function getByPath($page_path, $post_type = 'page')
+    {
+
+        $page_path = rawurlencode(urldecode($page_path));
+        $page_path = str_replace('%2F', '/', $page_path);
+        $page_path = str_replace('%20', ' ', $page_path);
+        $parts = explode('/', trim($page_path, '/'));
+        $escaped_parts = array_map('str_slug', $parts);
+
+        $in_string = "'" . implode("','", $escaped_parts) . "'";
+
+        if (is_array($post_type)) {
+            $post_types = $post_type;
+        } else {
+            $post_types = array($post_type, 'attachment');
+        }
+
+        $post_types = array_map('str_slug', $post_types);
+        $post_type_in_string = "'" . implode("','", $post_types) . "'";
+        $sql = "post_name IN ($in_string) AND post_type IN ($post_type_in_string)";
+
+        $pages = self::whereRaw($sql)->get()->keyBy('ID');
+
+        $revparts = array_reverse($parts);
+
+        $foundid = 0;
+        foreach ($pages as $page) {
+            if ($page->post_name == $revparts[0]) {
+                $count = 0;
+                $p = $page;
+
+                /*
+                 * Loop through the given path parts from right to left,
+                 * ensuring each matches the post ancestry.
+                 */
+                while ($p->post_parent != 0 && isset( $pages[$p->post_parent])) {
+                    $count++;
+                    $parent = $pages[$p->post_parent];
+                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count])
+                        break;
+                    $p = $parent;
+                }
+
+                if ($p->post_parent == 0 && $count + 1 == count($revparts) && $p->post_name == $revparts[$count]) {
+                    $foundid = $page->ID;
+                    if ($page->post_type == $post_type)
+                        break;
+                }
+            }
+        }
+
+        if ($foundid) {
+            return $pages[$foundid];
+        }
+    }
+
+    /**
      * @param string $key
      * @return mixed
      */


### PR DESCRIPTION
Added the getByPath method to Post model extracted the logic from WP source. Allowing retrieve pages with nested paths (parent pages).

Example: A child page with the following permalink: `parent/child`. 

This is useful in use cases where you need a "wildcard" path for the pages created in the backoffice.

So your last route may look like:

```php
/**
 * Catch all that verifies for WP pages.
 */
Route::get('{any}', function ($any) {
    $page = Corcel\Model\Post::getByPath($any);
    if ($page) return view('page',$page);
    abort(404);
})->where('any', '.*');
```