### PR TITLE
Added method getByPath to post model

### DIFF
--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -105,7 +105,7 @@ trait GetByPath
         $pagesWithTheSameName = $pages->filter(function ($page) use ($reverseParts) {
             return $page->post_name == $reverseParts[0];
         });
-        $pagesWithTheSameName->each(function($page) use (&$foundId, $pages, $reverseParts, $postType) {
+        $pagesWithTheSameName->each(function ($page) use (&$foundId, $pages, $reverseParts, $postType) {
             $count = 0;
             $currentPage = $page;
 

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -130,4 +130,5 @@ trait GetByPath
 
         return $foundId;
     }
+    
 }

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -102,31 +102,31 @@ trait GetByPath
     private static function searchIdInPath($pages, $reverseParts, $postType)
     {
         $foundId = 0;
-        $pagesFiltered = $pages->filter(function ($page) use ($reverseParts) {
+        $pagesWithTheSameName = $pages->filter(function ($page) use ($reverseParts) {
             return $page->post_name == $reverseParts[0];
         });
-        foreach ($pagesFiltered as $page) {
+        $pagesWithTheSameName->each(function($page) use (&$foundId, $pages, $reverseParts, $postType) {
             $count = 0;
-            $p = $page;
+            $currentPage = $page;
 
             /*
             * Loop through the given path parts from right to left,
             * ensuring each matches the post ancestry.
             */
-            while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
-                if (!isset($reverseParts[++$count]) || $pages[$p->post_parent]->post_name != $reverseParts[$count]) {
+            while ($currentPage->post_parent != 0 && isset($pages[$currentPage->post_parent])) {
+                if (!isset($reverseParts[++$count]) || $pages[$currentPage->post_parent]->post_name != $reverseParts[$count]) {
                     break;
                 }
-                $p = $pages[$p->post_parent];
+                $currentPage = $pages[$currentPage->post_parent];
             }
 
-            if ($p->post_parent == 0 && $count + 1 == count($reverseParts) && $p->post_name == $reverseParts[$count]) {
+            if ($currentPage->post_parent == 0 && $count + 1 == count($reverseParts) && $currentPage->post_name == $reverseParts[$count]) {
                 $foundId = $page->ID;
                 if ($page->post_type == $postType) {
-                    break;
+                    return false;
                 }
             }
-        }
+        });
 
         return $foundId;
     }

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -102,27 +102,28 @@ trait GetByPath
     private static function searchIdInPath($pages, $reverseParts, $postType)
     {
         $foundId = 0;
-        foreach ($pages as $page) {
-            if ($page->post_name == $reverseParts[0]) {
-                $count = 0;
-                $p = $page;
+        $pagesFiltered = $pages->filter(function ($page) use ($reverseParts) {
+            return $page->post_name == $reverseParts[0];
+        });
+        foreach ($pagesFiltered as $page) {
+            $count = 0;
+            $p = $page;
 
-                /*
-                * Loop through the given path parts from right to left,
-                * ensuring each matches the post ancestry.
-                */
-                while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
-                    if (!isset($reverseParts[++$count]) || $pages[$p->post_parent]->post_name != $reverseParts[$count]) {
-                        break;
-                    }
-                    $p = $pages[$p->post_parent];
+            /*
+            * Loop through the given path parts from right to left,
+            * ensuring each matches the post ancestry.
+            */
+            while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
+                if (!isset($reverseParts[++$count]) || $pages[$p->post_parent]->post_name != $reverseParts[$count]) {
+                    break;
                 }
+                $p = $pages[$p->post_parent];
+            }
 
-                if ($p->post_parent == 0 && $count + 1 == count($reverseParts) && $p->post_name == $reverseParts[$count]) {
-                    $foundId = $page->ID;
-                    if ($page->post_type == $postType) {
-                        break;
-                    }
+            if ($p->post_parent == 0 && $count + 1 == count($reverseParts) && $p->post_name == $reverseParts[$count]) {
+                $foundId = $page->ID;
+                if ($page->post_type == $postType) {
+                    break;
                 }
             }
         }

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Corcel\Concerns;
+
+/**
+ * Trait GetByPath
+ *
+ * @package Corcel\Traits
+ * @author João Henrique S. Mendonça <joao.mendonca@pdmfc.com>
+ */
+trait GetByPath
+{
+    /**
+     * Retrieves a post (usually pages) given its path.
+     *
+     * @param string $page_path Page path.
+     * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
+     * @return \Corcel\Model\Post|null \Corcel\Model\Post on success, or null on failure.
+     */
+    public static function getByPath($page_path, $post_type = 'page')
+    {
+        $in_string = self::sanitisePathToSql($page_path);
+        $post_type_in_string = self::sanitiseTypesToSql($post_type);
+        $sql = "post_name IN ($in_string) AND post_type IN ($post_type_in_string)";
+
+        $pages = self::whereRaw($sql)->get()->keyBy('ID');
+
+        $revparts = self::reversePathParts($page_path);
+
+        $foundid = 0;
+        foreach ($pages as $page) {
+            if ($page->post_name == $revparts[0]) {
+                $count = 0;
+                $p = $page;
+
+                /*
+                * Loop through the given path parts from right to left,
+                * ensuring each matches the post ancestry.
+                */
+                while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
+                    $count++;
+                    $parent = $pages[$p->post_parent];
+                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count]) {
+                        break;
+                    }
+                    $p = $parent;
+                }
+
+                if ($p->post_parent == 0 && $count + 1 == count($revparts) && $p->post_name == $revparts[$count]) {
+                    $foundid = $page->ID;
+                    if ($page->post_type == $post_type) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ($foundid) {
+            return $pages[$foundid];
+        }
+    }
+
+    /**
+     * Returns a sql string with the sanitized and exploded path
+     *
+     * @param string $path
+     * @return string
+     */
+    private static function sanitisePathToSql($path)
+    {
+        $parts = self::getPathParts($path);
+        $escaped_parts = array_map('str_slug', $parts);
+
+        return "'" . implode("','", $escaped_parts) . "'";
+    }
+
+    /**
+     * Returns an array of decoded path parts
+     *
+     * @param $path
+     * @return array
+     */
+    private static function getPathParts($path)
+    {
+        $page_path = rawurlencode(urldecode($path));
+        $page_path = str_replace('%2F', '/', $page_path);
+        $page_path = str_replace('%20', ' ', $page_path);
+        return explode('/', trim($page_path, '/'));
+    }
+
+    /**
+     * Returns an array of reversed path parts
+     *
+     * @param $path
+     * @return array
+     */
+    private static function reversePathParts($path)
+    {
+        return array_reverse(self::getPathParts($path));
+    }
+
+    /**
+     * Returns a sql string with the sanitized and exploded types
+     *
+     * @param string|array $type
+     * @return string
+     */
+    private static function sanitiseTypesToSql($type)
+    {
+        if (is_array($type)) {
+            $post_types = $type;
+        } else {
+            $post_types = array($type, 'attachment');
+        }
+
+        $post_types = array_map('str_slug', $post_types);
+        return "'" . implode("','", $post_types) . "'";
+    }
+}

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -112,12 +112,10 @@ trait GetByPath
                 * ensuring each matches the post ancestry.
                 */
                 while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
-                    $count++;
-                    $parent = $pages[$p->post_parent];
-                    if (!isset($reverseParts[$count]) || $parent->post_name != $reverseParts[$count]) {
+                    if (!isset($reverseParts[++$count]) || $pages[$p->post_parent]->post_name != $reverseParts[$count]) {
                         break;
                     }
-                    $p = $parent;
+                    $p = $pages[$p->post_parent];
                 }
 
                 if ($p->post_parent == 0 && $count + 1 == count($reverseParts) && $p->post_name == $reverseParts[$count]) {

--- a/src/Concerns/GetByPath.php
+++ b/src/Concerns/GetByPath.php
@@ -130,5 +130,4 @@ trait GetByPath
 
         return $foundId;
     }
-    
 }

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -398,6 +398,69 @@ class Post extends Model
     }
 
     /**
+     * Retrieves a post (usually pages) given its path.
+     *
+     * @param string $page_path Page path.
+     * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
+     * @return \Corcel\Model\Post|null \Corcel\Model\Post on success, or null on failure.
+     */
+    public static function getByPath($page_path, $post_type = 'page')
+    {
+
+        $page_path = rawurlencode(urldecode($page_path));
+        $page_path = str_replace('%2F', '/', $page_path);
+        $page_path = str_replace('%20', ' ', $page_path);
+        $parts = explode('/', trim($page_path, '/'));
+        $escaped_parts = array_map('str_slug', $parts);
+
+        $in_string = "'" . implode("','", $escaped_parts) . "'";
+
+        if (is_array($post_type)) {
+            $post_types = $post_type;
+        } else {
+            $post_types = array($post_type, 'attachment');
+        }
+
+        $post_types = array_map('str_slug', $post_types);
+        $post_type_in_string = "'" . implode("','", $post_types) . "'";
+        $sql = "post_name IN ($in_string) AND post_type IN ($post_type_in_string)";
+
+        $pages = self::whereRaw($sql)->get()->keyBy('ID');
+
+        $revparts = array_reverse($parts);
+
+        $foundid = 0;
+        foreach ($pages as $page) {
+            if ($page->post_name == $revparts[0]) {
+                $count = 0;
+                $p = $page;
+
+                /*
+                 * Loop through the given path parts from right to left,
+                 * ensuring each matches the post ancestry.
+                 */
+                while ($p->post_parent != 0 && isset( $pages[$p->post_parent])) {
+                    $count++;
+                    $parent = $pages[$p->post_parent];
+                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count])
+                        break;
+                    $p = $parent;
+                }
+
+                if ($p->post_parent == 0 && $count + 1 == count($revparts) && $p->post_name == $revparts[$count]) {
+                    $foundid = $page->ID;
+                    if ($page->post_type == $post_type)
+                        break;
+                }
+            }
+        }
+
+        if ($foundid) {
+            return $pages[$foundid];
+        }
+    }
+
+    /**
      * @param string $key
      * @return mixed
      */

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -406,7 +406,6 @@ class Post extends Model
      */
     public static function getByPath($page_path, $post_type = 'page')
     {
-
         $page_path = rawurlencode(urldecode($page_path));
         $page_path = str_replace('%2F', '/', $page_path);
         $page_path = str_replace('%20', ' ', $page_path);
@@ -439,18 +438,20 @@ class Post extends Model
                  * Loop through the given path parts from right to left,
                  * ensuring each matches the post ancestry.
                  */
-                while ($p->post_parent != 0 && isset( $pages[$p->post_parent])) {
+                while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
                     $count++;
                     $parent = $pages[$p->post_parent];
-                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count])
+                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count]) {
                         break;
+                    }
                     $p = $parent;
                 }
 
                 if ($p->post_parent == 0 && $count + 1 == count($revparts) && $p->post_name == $revparts[$count]) {
                     $foundid = $page->ID;
-                    if ($page->post_type == $post_type)
+                    if ($page->post_type == $post_type) {
                         break;
+                    }
                 }
             }
         }

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -8,6 +8,7 @@ use Corcel\Concerns\CustomTimestamps;
 use Corcel\Concerns\MetaFields;
 use Corcel\Concerns\OrderScopes;
 use Corcel\Concerns\Shortcodes;
+use Corcel\Concerns\GetByPath;
 use Corcel\Corcel;
 use Corcel\Model;
 use Corcel\Model\Builder\PostBuilder;
@@ -26,6 +27,7 @@ class Post extends Model
     use AdvancedCustomFields;
     use MetaFields;
     use Shortcodes;
+    use GetByPath;
     use OrderScopes;
     use CustomTimestamps;
 
@@ -395,70 +397,6 @@ class Post extends Model
         }
 
         return false;
-    }
-
-    /**
-     * Retrieves a post (usually pages) given its path.
-     *
-     * @param string $page_path Page path.
-     * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
-     * @return \Corcel\Model\Post|null \Corcel\Model\Post on success, or null on failure.
-     */
-    public static function getByPath($page_path, $post_type = 'page')
-    {
-        $page_path = rawurlencode(urldecode($page_path));
-        $page_path = str_replace('%2F', '/', $page_path);
-        $page_path = str_replace('%20', ' ', $page_path);
-        $parts = explode('/', trim($page_path, '/'));
-        $escaped_parts = array_map('str_slug', $parts);
-
-        $in_string = "'" . implode("','", $escaped_parts) . "'";
-
-        if (is_array($post_type)) {
-            $post_types = $post_type;
-        } else {
-            $post_types = array($post_type, 'attachment');
-        }
-
-        $post_types = array_map('str_slug', $post_types);
-        $post_type_in_string = "'" . implode("','", $post_types) . "'";
-        $sql = "post_name IN ($in_string) AND post_type IN ($post_type_in_string)";
-
-        $pages = self::whereRaw($sql)->get()->keyBy('ID');
-
-        $revparts = array_reverse($parts);
-
-        $foundid = 0;
-        foreach ($pages as $page) {
-            if ($page->post_name == $revparts[0]) {
-                $count = 0;
-                $p = $page;
-
-                /*
-                 * Loop through the given path parts from right to left,
-                 * ensuring each matches the post ancestry.
-                 */
-                while ($p->post_parent != 0 && isset($pages[$p->post_parent])) {
-                    $count++;
-                    $parent = $pages[$p->post_parent];
-                    if (!isset($revparts[$count]) || $parent->post_name != $revparts[$count]) {
-                        break;
-                    }
-                    $p = $parent;
-                }
-
-                if ($p->post_parent == 0 && $count + 1 == count($revparts) && $p->post_name == $revparts[$count]) {
-                    $foundid = $page->ID;
-                    if ($page->post_type == $post_type) {
-                        break;
-                    }
-                }
-            }
-        }
-
-        if ($foundid) {
-            return $pages[$foundid];
-        }
     }
 
     /**


### PR DESCRIPTION
Added the getByPath method to Post model extracted the logic from WP source. Allowing retrieve pages with nested paths (parent pages).

Example: A child page with the following permalink: `parent/child`. 

This is useful in use cases where you need a "wildcard" path for the pages created in the backoffice.

So your last route may look like:

```php
/**
 * Catch all that verifies for WP pages.
 */
Route::get('{any}', function ($any) {
    $page = Corcel\Model\Post::getByPath($any);
    if ($page) return view('page',$page);
    abort(404);
})->where('any', '.*');
```