### PR TITLE
Menu performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,19 +586,19 @@ To get a menu by its slug, use the syntax below. The menu items will be loaded i
 
 The currently supported menu items are: Pages, Posts, Custom Links and Categories.
 
-Once you'll have instances of `MenuItem` class, if you want to use the original instance (like the original Page or Term, for example), just call the `MenuItem::instance()` method. The `MenuItem` object is just a post with `post_type` equals `nav_menu_item`:
+Once you'll have instances of `MenuItem` class, if you want to use the original instance (like the original Page or Term, for example), just access the `MenuItem::object()` relation. The `MenuItem` object is just a post with `post_type` equals `nav_menu_item`:
 
 ```php
 $menu = Menu::slug('primary')->first();
 
 foreach ($menu->items as $item) {
-    echo $item->instance()->title; // if it's a Post
-    echo $item->instance()->name; // if it's a Term
-    echo $item->instance()->link_text; // if it's a custom link
+    echo $item->object->title; // if it's a Post
+    echo $item->object->name; // if it's a Term
+    echo $item->object->link_text; // if it's a custom link
 }
 ```
 
-The `instance()` method will return the matching object:
+`object` will return the matching object:
 
 - `Post` instance for `post` menu item;
 - `Page` instance for `page` menu item;

--- a/src/Laravel/CorcelServiceProvider.php
+++ b/src/Laravel/CorcelServiceProvider.php
@@ -6,6 +6,11 @@ use Auth;
 use Corcel\Corcel;
 use Corcel\Laravel\Auth\AuthUserProvider;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Corcel\Model\Post;
+use Corcel\Model\Page;
+use Corcel\Model\CustomLink;
+use Corcel\Model\Taxonomy;
 
 /**
  * Class CorcelServiceProvider
@@ -23,6 +28,7 @@ class CorcelServiceProvider extends ServiceProvider
     {
         $this->publishConfigFile();
         $this->registerAuthProvider();
+        $this->registerMorphMaps();
     }
     
     /**
@@ -45,6 +51,21 @@ class CorcelServiceProvider extends ServiceProvider
                 return new AuthUserProvider($config);
             });
         }
+    }
+
+    /**
+     * register morph maps for polymorphic relations
+     *
+     * @return void
+     */
+    public function registerMorphMaps()
+    {
+        Relation::morphMap([
+            'post' => Post::class,
+            'page' => Page::class,
+            'custom' => CustomLink::class,
+            'category' => Taxonomy::class,
+        ]);
     }
 
     /**

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -30,6 +30,24 @@ class MenuItem extends Post
     /**
      * @return Post|Page|CustomLink|Taxonomy
      */
+    public function object()
+    {
+        return $this->morphTo();
+    }
+
+    public function getObjectIdAttribute()
+    {
+        return $this->meta->_menu_item_object_id;
+    }
+
+    public function getObjectTypeAttribute()
+    {
+        return $this->meta->_menu_item_object;
+    }
+
+    /**
+     * @return Post|Page|CustomLink|Taxonomy
+     */
     public function parent()
     {
         if ($className = $this->getClassName()) {
@@ -46,8 +64,7 @@ class MenuItem extends Post
     public function instance()
     {
         if ($className = $this->getClassName()) {
-            return (new $className)->newQuery()
-                ->find($this->meta->_menu_item_object_id);
+            return $this->object;
         }
 
         return null;

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -59,6 +59,7 @@ class MenuItem extends Post
     }
 
     /**
+     * @deprecated deprecated in favor of object()
      * @return Post|Page|CustomLink|Taxonomy
      */
     public function instance()

--- a/tests/Unit/Model/MenuTest.php
+++ b/tests/Unit/Model/MenuTest.php
@@ -7,6 +7,7 @@ use Corcel\Model\Menu;
 use Corcel\Model\MenuItem;
 use Corcel\Model\Post;
 use Corcel\Model\Taxonomy;
+use Corcel\Model\Page;
 
 /**
  * Class MenuTest
@@ -93,7 +94,7 @@ class MenuTest extends \Corcel\Tests\TestCase
             return $item->meta->_menu_item_object === 'post';
         });
 
-        $parent = $posts->first()->instance();
+        $parent = $posts->first()->object;
         $child = $posts->last();
 
         $this->assertEquals($parent->ID, $child->parent()->ID);
@@ -122,7 +123,9 @@ class MenuTest extends \Corcel\Tests\TestCase
 
         $this->assertEquals('Foobar', $item->post_title);
         $this->assertEquals('Foobar', $item->instance()->link_text);
+        $this->assertEquals('Foobar', $item->object->link_text);
         $this->assertEquals('http://example.com', $item->meta->_menu_item_url);
+        $this->assertEquals('http://example.com', $item->object->url);
         $this->assertEquals('http://example.com', $item->instance()->url);
     }
 
@@ -138,6 +141,8 @@ class MenuTest extends \Corcel\Tests\TestCase
         });
 
         $pages->each(function (MenuItem $item) {
+            $this->assertEquals('page', $item->object_type);
+            $this->assertInstanceOf(Page::class, $item->object);
             $this->assertEquals("page-title", $item->instance()->post_title);
             $this->assertEquals("page-content", $item->instance()->post_content);
         });
@@ -155,6 +160,8 @@ class MenuTest extends \Corcel\Tests\TestCase
         });
 
         $posts->each(function (MenuItem $item) {
+            $this->assertEquals('post', $item->object_type);
+            $this->assertInstanceOf(Post::class, $item->object);
             $this->assertEquals("post-title", $item->instance()->title);
             $this->assertEquals("post-content", $item->instance()->content);
         });
@@ -172,6 +179,8 @@ class MenuTest extends \Corcel\Tests\TestCase
         });
 
         $posts->each(function (MenuItem $item) {
+            $this->assertEquals('custom', $item->object_type);
+            $this->assertInstanceOf(CustomLink::class, $item->object);
             $this->assertEquals("http://example.com", $item->instance()->url);
             $this->assertEquals("custom-link-text", $item->instance()->link_text);
         });
@@ -189,6 +198,8 @@ class MenuTest extends \Corcel\Tests\TestCase
         });
 
         $posts->each(function (MenuItem $item) {
+            $this->assertEquals('category', $item->object_type);
+            $this->assertInstanceOf(Taxonomy::class, $item->object);
             $this->assertEquals("Bar", $item->instance()->name);
             $this->assertEquals("bar", $item->instance()->slug);
         });


### PR DESCRIPTION
Rewrote the relation in MenuItem to the related post/page/etc using polymorphic relations. This way, the related object will be eager loaded and cached which reduces queries dramatically when accessing it multiple times.