### PR TITLE
Fixed MenuItem parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,11 +609,11 @@ foreach ($menu->items as $item) {
 
 To handle multi-levels menus, loop through all the menu items to put them on the right levels, for example.
 
-You can use the `MenuItem::parent_item()` relation to retrieve the parent instance of that menu item:
+You can use the `MenuItem::parentItem()` relation to retrieve the parent instance of that menu item:
 
 ```php
 $items = Menu::slug('foo')->first()->items;
-$parentItem = $items->first()->parent_item; // MenuItem or null for top-level items
+$parentItem = $items->first()->parentItem; // MenuItem or null for top-level items
 $parent_object = $parentItem->object; // Post, Page, CustomLink or Term (category)
 ```
 

--- a/README.md
+++ b/README.md
@@ -609,14 +609,15 @@ foreach ($menu->items as $item) {
 
 To handle multi-levels menus, loop through all the menu items to put them on the right levels, for example.
 
-You can use the `MenuItem::parent()` method to retrieve the parent instance of that menu item:
+You can use the `MenuItem::parent_item()` relation to retrieve the parent instance of that menu item:
 
 ```php
 $items = Menu::slug('foo')->first()->items;
-$parent = $items->first()->parent(); // Post, Page, CustomLink or Term (category)
+$parentItem = $items->first()->parent_item; // MenuItem or null for top-level items
+$parent_object = $parentItem->object; // Post, Page, CustomLink or Term (category)
 ```
 
-To group menu items according their parents, you can use the `->groupBy()` method in the `$menu->items` collection, grouping menu items by their `$item->parent()->ID`.
+To group menu items according their parents, you can use the `->groupBy()` method in the `$menu->items` collection, grouping menu items by their `$item->parent_item_id`.
 
 To read more about the `groupBy()` method [take a look on the Laravel documentation](https://laravel.com/docs/5.4/collections#method-groupby).
 

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -47,7 +47,6 @@ class MenuItem extends Post
 
     /**
      * Get the parent menu item (if any)
-     * 
      * @return MenuItem|null
      */
     public function parent_item()

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -49,7 +49,7 @@ class MenuItem extends Post
      * Get the parent menu item (if any)
      * @return MenuItem|null
      */
-    public function parent_item()
+    public function parentItem()
     {
         return $this->belongsTo(MenuItem::class);
     }
@@ -60,11 +60,11 @@ class MenuItem extends Post
     }
 
     /**
-     * @deprecated in favor of parent_item()->object
+     * @deprecated in favor of parentItem()->object
      */
     public function parent()
     {
-        return $this->parent_item->object ?? null;
+        return $this->parentItem->object ?? null;
     }
 
     /**

--- a/src/Model/MenuItem.php
+++ b/src/Model/MenuItem.php
@@ -46,16 +46,26 @@ class MenuItem extends Post
     }
 
     /**
-     * @return Post|Page|CustomLink|Taxonomy
+     * Get the parent menu item (if any)
+     * 
+     * @return MenuItem|null
+     */
+    public function parent_item()
+    {
+        return $this->belongsTo(MenuItem::class);
+    }
+
+    public function getParentItemIdAttribute()
+    {
+        return $this->meta->_menu_item_menu_item_parent;
+    }
+
+    /**
+     * @deprecated in favor of parent_item()->object
      */
     public function parent()
     {
-        if ($className = $this->getClassName()) {
-            return (new $className)->newQuery()
-                ->find($this->meta->_menu_item_menu_item_parent);
-        }
-
-        return null;
+        return $this->parent_item->object ?? null;
     }
 
     /**

--- a/tests/Unit/Model/MenuTest.php
+++ b/tests/Unit/Model/MenuTest.php
@@ -90,15 +90,16 @@ class MenuTest extends \Corcel\Tests\TestCase
     {
         $menu = $this->createComplexMenu();
 
-        $posts = $menu->items->filter(function ($item) {
-            return $item->meta->_menu_item_object === 'post';
-        });
+        $parentItem = $menu->items->get(1);
+        $childItem = $menu->items->get(2);
+        $parentObject = $parentItem->object;
 
-        $parent = $posts->first()->object;
-        $child = $posts->last();
+        $this->assertNull($parentItem->parent_item);
 
-        $this->assertEquals($parent->ID, $child->parent()->ID);
-        $this->assertEquals($parent->post_name, $child->parent()->post_name);
+        $this->assertEquals($parentItem->ID, $childItem->parent_item_id);
+
+        $this->assertEquals($parentObject->ID, $childItem->parent()->ID);
+        $this->assertEquals($parentObject->post_name, $childItem->parent()->post_name);
     }
 
     /**
@@ -230,8 +231,8 @@ class MenuTest extends \Corcel\Tests\TestCase
 
         $this->buildPage($menu);
 
-        $post = $this->buildPost($menu);
-        $this->buildPost($menu, $post->ID);
+        $item = $this->buildPost($menu);
+        $this->buildPost($menu, $item->ID);
 
         $this->buildCustomLink($menu);
         $this->buildCategory($menu);
@@ -293,7 +294,7 @@ class MenuTest extends \Corcel\Tests\TestCase
 
         $menu->items()->save($item);
 
-        return $post;
+        return $item;
     }
 
     /**

--- a/tests/Unit/Model/MenuTest.php
+++ b/tests/Unit/Model/MenuTest.php
@@ -94,7 +94,7 @@ class MenuTest extends \Corcel\Tests\TestCase
         $childItem = $menu->items->get(2);
         $parentObject = $parentItem->object;
 
-        $this->assertNull($parentItem->parent_item);
+        $this->assertNull($parentItem->parentItem);
 
         $this->assertEquals($parentItem->ID, $childItem->parent_item_id);
 


### PR DESCRIPTION
Fixed the MenuItem parent relation using laravel belongsTo relation. Also fixed the tests, a menu item's parent id (in _menu_item_menu_item_parent) contains the id of the parent menu item, not the parent's linked post/page/etc.
I left the original parent() method there (which still points to the parent's post/page), so it should not break any implementations, just marked it as deprecated.
This should also fix #365 
I can send a pull request for 2.6 after the other menu item pr is merged, otherwise it gets too confusing ;)