### PR TITLE
isLumen() fixes

### DIFF
--- a/src/Corcel.php
+++ b/src/Corcel.php
@@ -17,15 +17,9 @@ class Corcel
      */
     public static function isLaravel()
     {
-        return function_exists('app') &&
-            app() instanceof Application;
-    }
-
-    /**
-     * @return bool
-     */
-    public static function isLumen()
-    {
-        return preg_match('/Lumen', app()->version()) === 1;
+        return function_exists('app') && (
+            app() instanceof Application ||
+            strpos(app()->version(), 'Lumen') === 0
+        );
     }
 }

--- a/src/Laravel/CorcelServiceProvider.php
+++ b/src/Laravel/CorcelServiceProvider.php
@@ -30,7 +30,7 @@ class CorcelServiceProvider extends ServiceProvider
         $this->registerAuthProvider();
         $this->registerMorphMaps();
     }
-    
+
     /**
      * @return void
      */


### PR DESCRIPTION
`isLumen()` regex was invalid and it should be used too where `isLaravel()` is used
Please merge to 2.5 and 2.6 branches.