### PR TITLE
Disable xdebug for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: trusty
 sudo: required
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer install
 


### PR DESCRIPTION
This PR disables xdebug PHP extension on Travis CI, making running tests a bit faster.