### PR TITLE
TermRelationship $incrementing fix

### DIFF
--- a/src/Model/TermRelationship.php
+++ b/src/Model/TermRelationship.php
@@ -28,6 +28,11 @@ class TermRelationship extends Model
     public $timestamps = false;
 
     /**
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function post()


### PR DESCRIPTION
Saving a `TermRelationship` model produces an exception (caused by composite primary key), which can be resolved by setting `$incrementing` to `false`.