### PR TITLE
Change version of hautelook/phpass package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "5.6.*",
         "illuminate/support": "5.6.*",
         "fzaninotto/faker": "^1.6",
-        "hautelook/phpass": "0.3.4",
+        "hautelook/phpass": "0.3.*",
         "thunderer/shortcode": "^0.6.2"
     },
     "require-dev": {


### PR DESCRIPTION
> this PR fixes #408 👍

`hautelook/phpass` package is currently on `0.3.5` and Corcel was requiring `0.3.4`. now it was changed to `0.3.*` to allow minor updates.

thanks @audetcameron for reporting! 😎