### PR TITLE
Add Author Description, so description/bio is passed through to model

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -64,6 +64,7 @@ class User extends Model implements Authenticatable, CanResetPassword
         'nickname' => ['meta' => 'nickname'],
         'first_name' => ['meta' => 'first_name'],
         'last_name' => ['meta' => 'last_name'],
+	'description' => ['meta' => 'description'],
         'created_at' => 'user_registered',
     ];
 

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -64,7 +64,7 @@ class User extends Model implements Authenticatable, CanResetPassword
         'nickname' => ['meta' => 'nickname'],
         'first_name' => ['meta' => 'first_name'],
         'last_name' => ['meta' => 'last_name'],
-	'description' => ['meta' => 'description'],
+        'description' => ['meta' => 'description'],
         'created_at' => 'user_registered',
     ];
 


### PR DESCRIPTION
This is a very minor change, just to allow the Author Description to be passed through from the WordPress Database to Corcel. 

This is particularly useful when wishing to show the common "Author Bio" next to blog posts.