### PR TITLE
Add scope for hasMetaLike()

### DIFF
--- a/src/Traits/HasMetaFields.php
+++ b/src/Traits/HasMetaFields.php
@@ -69,7 +69,35 @@ trait HasMetaFields
 
         return $query;
     }
+   
+    /**
+     * @param Builder $query
+     * @param string $meta
+     * @param mixed $value
+     * @return Builder
+     */
+    public function scopeHasMetaLike(Builder $query, $meta, $value = null)
+    {
+        if (!is_array($meta)) {
+            $meta = [$meta => $value];
+        }
 
+        foreach ($meta as $key => $value) {
+            $query->whereHas('meta', function ($query) use ($key, $value) {
+                if (is_string($key)) {
+                    $query->where('meta_key', 'like', $key);
+
+                    return is_null($value) ? $query : // 'foo' => null
+                        $query->where('meta_value', 'like', $value); // 'foo' => 'bar'
+                }
+
+                return $query->where('meta_key', 'like', $value); // 0 => 'foo'
+            });
+        }
+
+        return $query;
+    }
+    
     /**
      * @param string $key
      * @param mixed $value


### PR DESCRIPTION
Allow users to do a like search on meta values.

I couldn't figure out an elegant way to do this with Corcel as it currently is, so I added this for our own use.

My current use-cases are doing a case-insensitive search on posts by category, but I can also see wanting to retrieve by "category%".