### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/tests/Unit/Model/Meta/PostMetaTest.php
+++ b/tests/Unit/Model/Meta/PostMetaTest.php
@@ -30,7 +30,7 @@ class PostMetaTest extends \Corcel\Tests\TestCase
         $meta = factory(PostMeta::class)->create();
 
         $this->assertNotNull($meta);
-        $this->assertTrue(is_int($meta->meta_id));
+        $this->assertInternalType('int', $meta->meta_id);
     }
 
     /**

--- a/tests/Unit/Model/OptionTest.php
+++ b/tests/Unit/Model/OptionTest.php
@@ -56,8 +56,8 @@ class OptionTest extends \Corcel\Tests\TestCase
 
         $options = Option::asArray();
 
-        $this->assertTrue(is_array($options));
-        $this->assertTrue(count($options) > 0);
+        $this->assertInternalType('array', $options);
+        $this->assertGreaterThan(0, count($options));
     }
 
     /**

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -37,7 +37,7 @@ class PostTest extends \Corcel\Tests\TestCase
     {
         $post = factory(Post::class)->create();
 
-        $this->assertTrue(is_int($post->ID));
+        $this->assertInternalType('int', $post->ID);
         $this->assertGreaterThan(0, $post->ID);
     }
 

--- a/tests/Unit/Model/TaxonomyTest.php
+++ b/tests/Unit/Model/TaxonomyTest.php
@@ -98,7 +98,7 @@ class TaxonomyTest extends \Corcel\Tests\TestCase
 
         $post = $taxonomy->posts->first();
 
-        $this->assertTrue(count($post->keywords) > 0);
+        $this->assertGreaterThan(0, count($post->keywords));
     }
 
     /**

--- a/tests/Unit/Model/TermTest.php
+++ b/tests/Unit/Model/TermTest.php
@@ -38,7 +38,7 @@ class TermTest extends \Corcel\Tests\TestCase
         $meta = $term->meta;
 
         $this->assertNotEmpty($term->meta);
-        $this->assertTrue($meta->count() > 0);
+        $this->assertGreaterThan(0, $meta->count());
         $this->assertEquals('bar', $term->meta->foo);
     }
 

--- a/tests/Unit/Model/ThumbnailTest.php
+++ b/tests/Unit/Model/ThumbnailTest.php
@@ -43,7 +43,7 @@ class ThumbnailTest extends \Corcel\Tests\TestCase
         $meta = $this->createThumbnailMetaWithAttachment();
 
         $this->assertInstanceOf(Attachment::class, $meta->attachment);
-        $this->assertTrue(is_string($meta->post->image));
+        $this->assertInternalType('string', $meta->post->image);
     }
 
     /**


### PR DESCRIPTION
Using dedicated PHPUnit assertions, we can get better error messages that help us debug errors:

```diff
-$this->assertTrue(1 === 2); // Failed asserting that false is true.
+$this->assertSame(2, 1); // Failed asserting that 2 is identical to 1.
```