### PR TITLE
Add method to make easier to add terms to post

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         }
     },
     "minimum-stability": "stable",
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/src/Concerns/TaxonomySupport.php
+++ b/src/Concerns/TaxonomySupport.php
@@ -5,6 +5,12 @@ namespace Corcel\Concerns;
 use Corcel\Model\Taxonomy;
 use Corcel\Model\Term;
 
+/**
+ * Trait TaxonomySupport
+ *
+ * @package Corcel\Concerns
+ * @author Junior Grossi <juniorgro@gmail.com>
+ */
 trait TaxonomySupport
 {
     /**

--- a/src/Concerns/TaxonomySupport.php
+++ b/src/Concerns/TaxonomySupport.php
@@ -65,14 +65,16 @@ trait TaxonomySupport
      */
     public function getTermsAttribute()
     {
-        return $this->taxonomies->groupBy(function ($taxonomy) {
-            return $taxonomy->taxonomy == 'post_tag' ?
-                'tag' : $taxonomy->taxonomy;
-        })->map(function ($group) {
-            return $group->mapWithKeys(function ($item) {
-                return [$item->term->slug => $item->term->name];
-            });
-        })->toArray();
+        return $this->taxonomies
+            ->groupBy(function ($taxonomy) {
+                return $taxonomy->taxonomy == 'post_tag' ?
+                    'tag' : $taxonomy->taxonomy;
+            })->map(function ($group) {
+                return $group->mapWithKeys(function ($item) {
+                    return [$item->term->slug => $item->term->name];
+                });
+            })
+            ->toArray();
     }
 
     /**
@@ -80,20 +82,18 @@ trait TaxonomySupport
      *
      * @return string
      */
-    public function getMainCategoryAttribute()
+    public function getMainCategoryAttribute(): string
     {
-        $mainCategory = 'Uncategorized';
+        $main_category = 'Uncategorized';
 
         if (!empty($this->terms)) {
-            $taxonomies = array_values($this->terms);
-
-            if (!empty($taxonomies[0])) {
-                $terms = array_values($taxonomies[0]);
-                $mainCategory = $terms[0];
+            $first_taxonomy = array_first($this->terms);
+            if (!empty($first_taxonomy)) {
+                $main_category = array_first(array_values($first_taxonomy));
             }
         }
 
-        return $mainCategory;
+        return $main_category;
     }
 
     /**
@@ -101,11 +101,14 @@ trait TaxonomySupport
      *
      * @return array
      */
-    public function getKeywordsAttribute()
+    public function getKeywordsAttribute(): array
     {
-        return collect($this->terms)->map(function ($taxonomy) {
-            return collect($taxonomy)->values();
-        })->collapse()->toArray();
+        return collect($this->terms)
+            ->map(function ($taxonomy) {
+                return collect($taxonomy)->values();
+            })
+            ->collapse()
+            ->toArray();
     }
 
     /**
@@ -113,7 +116,7 @@ trait TaxonomySupport
      *
      * @return string
      */
-    public function getKeywordsStrAttribute()
+    public function getKeywordsStrAttribute(): string
     {
         return implode(',', (array) $this->keywords);
     }
@@ -130,9 +133,7 @@ trait TaxonomySupport
             ->first();
 
         if ($taxonomy && $taxonomy->term) {
-            return str_replace(
-                'post-format-', '', $taxonomy->term->slug
-            );
+            return str_replace('post-format-', '', $taxonomy->term->slug);
         }
 
         return false;

--- a/src/Concerns/TaxonomySupport.php
+++ b/src/Concerns/TaxonomySupport.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Corcel\Concerns;
+
+use Corcel\Model\Taxonomy;
+use Corcel\Model\Term;
+
+trait TaxonomySupport
+{
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function taxonomies()
+    {
+        return $this->belongsToMany(
+            Taxonomy::class, 'term_relationships', 'object_id', 'term_taxonomy_id'
+        );
+    }
+
+    /**
+     * Add a new term and taxonomy to the post
+     *
+     * @param string $taxonomy
+     * @param string $term
+     * @return Term
+     */
+    public function addTerm(string $taxonomy, string $term): Term
+    {
+        $term = Term::query()->firstOrCreate([
+            'name' => $term,
+            'slug' => str_slug($term),
+        ]);
+
+        return tap($term, function (Term $term) use ($taxonomy) {
+            $this->taxonomies()->firstOrCreate([
+                'term_id' => $term->term_id,
+                'taxonomy' => $taxonomy,
+            ]);
+        });
+    }
+
+    /**
+     * Whether the post contains the term or not.
+     *
+     * @param string $taxonomy
+     * @param string $term
+     * @return bool
+     */
+    public function hasTerm($taxonomy, $term)
+    {
+        return isset($this->terms[$taxonomy]) &&
+            isset($this->terms[$taxonomy][$term]);
+    }
+
+    /**
+     * Gets all the terms arranged taxonomy => terms[].
+     *
+     * @return array
+     */
+    public function getTermsAttribute()
+    {
+        return $this->taxonomies->groupBy(function ($taxonomy) {
+            return $taxonomy->taxonomy == 'post_tag' ?
+                'tag' : $taxonomy->taxonomy;
+        })->map(function ($group) {
+            return $group->mapWithKeys(function ($item) {
+                return [$item->term->slug => $item->term->name];
+            });
+        })->toArray();
+    }
+
+    /**
+     * Gets the first term of the first taxonomy found.
+     *
+     * @return string
+     */
+    public function getMainCategoryAttribute()
+    {
+        $mainCategory = 'Uncategorized';
+
+        if (!empty($this->terms)) {
+            $taxonomies = array_values($this->terms);
+
+            if (!empty($taxonomies[0])) {
+                $terms = array_values($taxonomies[0]);
+                $mainCategory = $terms[0];
+            }
+        }
+
+        return $mainCategory;
+    }
+
+    /**
+     * Gets the keywords as array.
+     *
+     * @return array
+     */
+    public function getKeywordsAttribute()
+    {
+        return collect($this->terms)->map(function ($taxonomy) {
+            return collect($taxonomy)->values();
+        })->collapse()->toArray();
+    }
+
+    /**
+     * Gets the keywords as string.
+     *
+     * @return string
+     */
+    public function getKeywordsStrAttribute()
+    {
+        return implode(',', (array) $this->keywords);
+    }
+
+    /**
+     * Get the post format, like the WP get_post_format() function.
+     *
+     * @return bool|string
+     */
+    public function getFormat()
+    {
+        $taxonomy = $this->taxonomies()
+            ->where('taxonomy', 'post_format')
+            ->first();
+
+        if ($taxonomy && $taxonomy->term) {
+            return str_replace(
+                'post-format-', '', $taxonomy->term->slug
+            );
+        }
+
+        return false;
+    }
+}

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -242,6 +242,13 @@ class Post extends Model
             ->where('post_type', 'revision');
     }
 
+    /**
+     * Add a new term and taxonomy to the post
+     *
+     * @param string $taxonomy
+     * @param string $term
+     * @return Term
+     */
     public function addTerm(string $taxonomy, string $term): Term
     {
         $term = Term::query()->create([

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -244,11 +244,9 @@ class Post extends Model
 
     public function addTerm(string $taxonomy, string $term): Term
     {
-        // create first the term
         $term = Term::query()->create([
             'name' => $term,
             'slug' => str_slug($term),
-            'term_group' => 0,
         ]);
 
         return tap($term, function (Term $term) use ($taxonomy) {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -8,6 +8,7 @@ use Corcel\Concerns\CustomTimestamps;
 use Corcel\Concerns\MetaFields;
 use Corcel\Concerns\OrderScopes;
 use Corcel\Concerns\Shortcodes;
+use Corcel\Concerns\TaxonomySupport;
 use Corcel\Corcel;
 use Corcel\Model;
 use Corcel\Model\Builder\PostBuilder;
@@ -28,6 +29,7 @@ class Post extends Model
     use Shortcodes;
     use OrderScopes;
     use CustomTimestamps;
+    use TaxonomySupport;
 
     const CREATED_AT = 'post_date';
     const UPDATED_AT = 'post_modified';
@@ -183,16 +185,6 @@ class Post extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    public function taxonomies()
-    {
-        return $this->belongsToMany(
-            Taxonomy::class, 'term_relationships', 'object_id', 'term_taxonomy_id'
-        );
-    }
-
-    /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function comments()
@@ -243,41 +235,6 @@ class Post extends Model
     }
 
     /**
-     * Add a new term and taxonomy to the post
-     *
-     * @param string $taxonomy
-     * @param string $term
-     * @return Term
-     */
-    public function addTerm(string $taxonomy, string $term): Term
-    {
-        $term = Term::query()->firstOrCreate([
-            'name' => $term,
-            'slug' => str_slug($term),
-        ]);
-
-        return tap($term, function (Term $term) use ($taxonomy) {
-            $this->taxonomies()->firstOrCreate([
-                'term_id' => $term->term_id,
-                'taxonomy' => $taxonomy,
-            ]);
-        });
-    }
-
-    /**
-     * Whether the post contains the term or not.
-     *
-     * @param string $taxonomy
-     * @param string $term
-     * @return bool
-     */
-    public function hasTerm($taxonomy, $term)
-    {
-        return isset($this->terms[$taxonomy]) &&
-            isset($this->terms[$taxonomy][$term]);
-    }
-
-    /**
      * @param string $postType
      */
     public function setPostType($postType)
@@ -323,66 +280,6 @@ class Post extends Model
     }
 
     /**
-     * Gets all the terms arranged taxonomy => terms[].
-     *
-     * @return array
-     */
-    public function getTermsAttribute()
-    {
-        return $this->taxonomies->groupBy(function ($taxonomy) {
-            return $taxonomy->taxonomy == 'post_tag' ?
-                'tag' : $taxonomy->taxonomy;
-        })->map(function ($group) {
-            return $group->mapWithKeys(function ($item) {
-                return [$item->term->slug => $item->term->name];
-            });
-        })->toArray();
-    }
-
-    /**
-     * Gets the first term of the first taxonomy found.
-     *
-     * @return string
-     */
-    public function getMainCategoryAttribute()
-    {
-        $mainCategory = 'Uncategorized';
-
-        if (!empty($this->terms)) {
-            $taxonomies = array_values($this->terms);
-
-            if (!empty($taxonomies[0])) {
-                $terms = array_values($taxonomies[0]);
-                $mainCategory = $terms[0];
-            }
-        }
-
-        return $mainCategory;
-    }
-
-    /**
-     * Gets the keywords as array.
-     *
-     * @return array
-     */
-    public function getKeywordsAttribute()
-    {
-        return collect($this->terms)->map(function ($taxonomy) {
-            return collect($taxonomy)->values();
-        })->collapse()->toArray();
-    }
-
-    /**
-     * Gets the keywords as string.
-     *
-     * @return string
-     */
-    public function getKeywordsStrAttribute()
-    {
-        return implode(',', (array) $this->keywords);
-    }
-
-    /**
      * @param string $name The post type slug
      * @param string $class The class to be instantiated
      */
@@ -397,26 +294,6 @@ class Post extends Model
     public static function clearRegisteredPostTypes()
     {
         static::$postTypes = [];
-    }
-
-    /**
-     * Get the post format, like the WP get_post_format() function.
-     *
-     * @return bool|string
-     */
-    public function getFormat()
-    {
-        $taxonomy = $this->taxonomies()
-            ->where('taxonomy', 'post_format')
-            ->first();
-
-        if ($taxonomy && $taxonomy->term) {
-            return str_replace(
-                'post-format-', '', $taxonomy->term->slug
-            );
-        }
-
-        return false;
     }
 
     /**

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -251,13 +251,13 @@ class Post extends Model
      */
     public function addTerm(string $taxonomy, string $term): Term
     {
-        $term = Term::query()->create([
+        $term = Term::query()->firstOrCreate([
             'name' => $term,
             'slug' => str_slug($term),
         ]);
 
         return tap($term, function (Term $term) use ($taxonomy) {
-            $this->taxonomies()->create([
+            $this->taxonomies()->firstOrCreate([
                 'term_id' => $term->term_id,
                 'taxonomy' => $taxonomy,
             ]);

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -278,7 +278,7 @@ class Post extends Model
     }
 
     /**
-     * @param string $postTyper
+     * @param string $postType
      */
     public function setPostType($postType)
     {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -242,6 +242,23 @@ class Post extends Model
             ->where('post_type', 'revision');
     }
 
+    public function addTerm(string $taxonomy, string $term): Term
+    {
+        // create first the term
+        $term = Term::query()->create([
+            'name' => $term,
+            'slug' => str_slug($term),
+            'term_group' => 0,
+        ]);
+
+        return tap($term, function (Term $term) use ($taxonomy) {
+            $this->taxonomies()->create([
+                'term_id' => $term->term_id,
+                'taxonomy' => $taxonomy,
+            ]);
+        });
+    }
+
     /**
      * Whether the post contains the term or not.
      *
@@ -256,7 +273,7 @@ class Post extends Model
     }
 
     /**
-     * @param string $postType
+     * @param string $postTyper
      */
     public function setPostType($postType)
     {

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -27,7 +27,21 @@ class Taxonomy extends Model
     /**
      * @var array
      */
+    protected $fillable = ['term_id', 'taxonomy', 'description', 'parent'];
+
+    /**
+     * @var array
+     */
     protected $with = ['term'];
+
+    /**
+     * @var array
+     */
+    protected $attributes = [
+        'description' => '',
+        'parent' => 0,
+        'count' => 1,
+    ];
 
     /**
      * @var bool

--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -28,6 +28,18 @@ class Term extends Model
     protected $primaryKey = 'term_id';
 
     /**
+     * @var array
+     */
+    protected $fillable = ['name', 'slug', 'term_group'];
+
+    /**
+     * @var array
+     */
+    protected $attributes = [
+        'term_group' => 0,
+    ];
+
+    /**
      * @var bool
      */
     public $timestamps = false;

--- a/tests/Unit/Model/TermTest.php
+++ b/tests/Unit/Model/TermTest.php
@@ -2,6 +2,7 @@
 
 namespace Corcel\Tests\Unit\Model;
 
+use Corcel\Model\Post;
 use Corcel\Model\Term;
 
 /**
@@ -64,6 +65,23 @@ class TermTest extends \Corcel\Tests\TestCase
         $meta = $term->meta()->where('meta_key', 'foo')->first();
 
         $this->assertEquals('bar', $meta->meta_value);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_added_at_post_level()
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create();
+
+        $this->assertEmpty($post->terms);
+        $term = $post->addTerm('category', 'foo');
+        $post->refresh();
+
+        $this->assertInstanceOf(Term::class, $term);
+        $this->assertTrue($post->hasTerm('category', 'foo'));
+        $this->assertFalse($post->hasTerm('category', 'bar'));
     }
 
     /**

--- a/tests/Unit/Model/TermTest.php
+++ b/tests/Unit/Model/TermTest.php
@@ -82,6 +82,7 @@ class TermTest extends \Corcel\Tests\TestCase
         $this->assertInstanceOf(Term::class, $term);
         $this->assertTrue($post->hasTerm('category', 'foo'));
         $this->assertFalse($post->hasTerm('category', 'bar'));
+        $this->assertEquals($term->taxonomy->taxonomy, 'category');
     }
 
     /**

--- a/tests/Unit/Model/TermTest.php
+++ b/tests/Unit/Model/TermTest.php
@@ -3,6 +3,7 @@
 namespace Corcel\Tests\Unit\Model;
 
 use Corcel\Model\Post;
+use Corcel\Model\Taxonomy;
 use Corcel\Model\Term;
 
 /**
@@ -83,6 +84,23 @@ class TermTest extends \Corcel\Tests\TestCase
         $this->assertTrue($post->hasTerm('category', 'foo'));
         $this->assertFalse($post->hasTerm('category', 'bar'));
         $this->assertEquals($term->taxonomy->taxonomy, 'category');
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_not_overridden_when_adding_at_post_level()
+    {
+        /** @var Post $post */
+        $post = factory(Post::class)->create();
+
+        $term1 = $post->addTerm('category', 'foo');
+        $term2 = $post->addTerm('category', 'foo');
+        $post->refresh();
+
+        $this->assertEquals($term1->term_id, $term2->term_id);
+        $this->assertEquals($term1->taxonomy, $term2->taxonomy);
+        $this->assertCount(1, Taxonomy::all());
     }
 
     /**


### PR DESCRIPTION
> This PR adds a `addTerm(string $taxonomy, string $term)` method to the `Post` model.

> It partially fixes issue #410. 

This way you don't have to worry about relations when adding terms to a given post:

```php
$post = Post::find(1);
$term_instance = $post->addTerm('foo', 'Foo Term'); // "Foo Term" slug would be "foo-term"
```

🔥😎