### PR TITLE
Create user hashing the password according to WP rules

### DIFF
--- a/src/Laravel/CorcelServiceProvider.php
+++ b/src/Laravel/CorcelServiceProvider.php
@@ -5,6 +5,8 @@ namespace Corcel\Laravel;
 use Auth;
 use Corcel\Corcel;
 use Corcel\Laravel\Auth\AuthUserProvider;
+use Corcel\Laravel\Observers\UserObserver;
+use Corcel\Model\User;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -23,6 +25,15 @@ class CorcelServiceProvider extends ServiceProvider
     {
         $this->publishConfigFile();
         $this->registerAuthProvider();
+        $this->registerObservers();
+    }
+
+    /**
+     * @return void
+     */
+    public function register()
+    {
+        //
     }
 
     /**
@@ -47,11 +58,8 @@ class CorcelServiceProvider extends ServiceProvider
         }
     }
 
-    /**
-     * @return void
-     */
-    public function register()
+    private function registerObservers(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 }

--- a/src/Laravel/Observers/UserObserver.php
+++ b/src/Laravel/Observers/UserObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Corcel\Laravel\Observers;
+
+use Carbon\Carbon;
+use Corcel\Model\User;
+
+/**
+ * Class UserObserver
+ *
+ * @package Corcel\Observers
+ * @author Junior Grossi <juniorgro@gmail.com>
+ */
+class UserObserver
+{
+    /**
+     * @param User $user
+     */
+    public function creating(User $user): void
+    {
+        $user->fill([
+            'user_nicename' => $user->user_nicename ?: $user->user_login,
+            'user_registered' => Carbon::now(),
+            'display_name' => $user->display_name ?: $user->user_login,
+        ]);
+    }
+}

--- a/src/Laravel/Observers/UserObserver.php
+++ b/src/Laravel/Observers/UserObserver.php
@@ -20,7 +20,7 @@ class UserObserver
     {
         $user->fill([
             'user_nicename' => $user->user_nicename ?: $user->user_login,
-            'user_registered' => Carbon::now(),
+            'user_registered' => $user->user_registered ?: Carbon::now(),
             'display_name' => $user->display_name ?: $user->user_login,
         ]);
     }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -7,6 +7,7 @@ use Corcel\Concerns\Aliases;
 use Corcel\Concerns\MetaFields;
 use Corcel\Concerns\OrderScopes;
 use Corcel\Model;
+use Corcel\Services\PasswordService;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword;
 
@@ -52,6 +53,20 @@ class User extends Model implements Authenticatable, CanResetPassword
      * @var array
      */
     protected $with = ['meta'];
+
+    /**
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * @var array
+     */
+    protected $attributes = [
+        'user_url' => '',
+        'user_activation_key' => '',
+        'user_status' => 0,
+    ];
 
     /**
      * @var array
@@ -199,6 +214,18 @@ class User extends Model implements Authenticatable, CanResetPassword
         $hash = !empty($this->email) ? md5(strtolower(trim($this->email))) : '';
 
         return sprintf('//secure.gravatar.com/avatar/%s?d=mm', $hash);
+    }
+
+    /**
+     * Hash the user password according to the WP rules
+     *
+     * @param string $password
+     */
+    public function setUserPassAttribute(string $password): void
+    {
+        $service = new PasswordService();
+
+        $this->attributes['user_pass'] = $service->makeHash($password);
     }
 
     /**

--- a/tests/Unit/AuthenticationTest.php
+++ b/tests/Unit/AuthenticationTest.php
@@ -57,9 +57,7 @@ class AuthenticationTest extends \Corcel\Tests\TestCase
      */
     public function it_can_validate_simple_passwords()
     {
-        $user = factory(User::class)->make([
-            'user_pass' => $this->checker->makeHash('foobar'),
-        ]);
+        $user = factory(User::class)->make(['user_pass' => 'foobar']);
 
         $this->assertTrue($this->provider->validateCredentials($user, ['password' => 'foobar']));
         $this->assertFalse($this->provider->validateCredentials($user, ['password' => 'foobaz']));
@@ -71,10 +69,7 @@ class AuthenticationTest extends \Corcel\Tests\TestCase
     public function it_can_validate_complex_passwords()
     {
         $password = ')_)E~O79}?w+5"4&6{!;ct>656Lx~5';
-
-        $user = factory(User::class)->make([
-            'user_pass' => $this->checker->makeHash($password),
-        ]);
+        $user = factory(User::class)->make(['user_pass' => $password]);
 
         $this->assertTrue($this->provider->validateCredentials($user, compact('password')));
         $this->assertFalse($this->provider->validateCredentials($user, ['password' => $password.'a']));
@@ -85,9 +80,7 @@ class AuthenticationTest extends \Corcel\Tests\TestCase
      */
     public function it_can_authenticate_users_using_auth_facade_with_email()
     {
-        factory(User::class)->create([
-            'user_pass' => $this->checker->makeHash('correct-password'),
-        ]);
+        factory(User::class)->create(['user_pass' => 'correct-password']);
 
         $this->assertTrue(Auth::validate([
             'email' => 'admin@example.com',
@@ -105,9 +98,7 @@ class AuthenticationTest extends \Corcel\Tests\TestCase
      */
     public function it_can_authenticate_users_using_auth_facade_with_username()
     {
-        factory(User::class)->create([
-            'user_pass' => $this->checker->makeHash('correct-password'),
-        ]);
+        factory(User::class)->create(['user_pass' => 'correct-password']);
 
         $this->assertTrue(Auth::validate([
             'username' => 'admin',


### PR DESCRIPTION
> This PR is related to #413 

WP uses a different password hashing algorithm than Laravel does. This PR adds a `UserObserver` class to fill required fields and a `User@setUserPassAttribute()` method to hash the password according to WP rules.

Now you can create users on the fly. The required params are `user_login`, `user_pass` and `user_email`. Others are filled by default and the password is hashed by default.

> ⚠️ WARNING: this PR changes the default hashing for user creation. Since then, every created user is gonna have the password hashed by the `PasswordService` class.

### TODO

- [ ] Add meta fields when creating the user.