### PR TITLE
Allow searching meta fields by LIKE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ There are multiples possibilities to query posts by their custom fields (meta) b
 To check if a meta key exists, use the `hasMeta()` scope:
 ```
 // Finds a published post with a meta flag.
-$post = Post::published()->hasMeta('featured_article'); 
+$post = Post::published()->hasMeta('featured_article')->first();
 ```
 
 If you want to precisely match a meta-field, you can use the `hasMeta()` scope with a value.

--- a/README.md
+++ b/README.md
@@ -259,21 +259,38 @@ $trueOrFalse = $post->saveMeta('foo', 'baz'); // boolean
 
 ### Querying Posts by Custom Fields (Meta)
 
-There are multiples possibilities to query posts by their custom fields (meta). Just use the `hasMeta()` scope under `Post` (actually for all models using the `HasMetaFields` trait) class:
+There are multiples possibilities to query posts by their custom fields (meta) by using scopes on a `Post` (or another other model which uses the `HasMetaFields` trait) class:
 
-```php
-// Using just one custom field
-$post = Post::published()->hasMeta('username', 'jgrossi')->first(); // setting key and value
-$post = Post::published()->hasMeta('username'); // setting just the key
+To check if a meta key exists, use the `hasMeta()` scope:
+```
+// Finds a published post with a meta flag.
+$post = Post::published()->hasMeta('featured_article'); 
 ```
 
-You can also use the `hasMeta()` scope passing an array as parameter:
+If you want to precisely match a meta-field, you can use the `hasMeta()` scope with a value.
+
+```php
+// Find a published post which matches both meta_key and meta_value.
+$post = Post::published()->hasMeta('username', 'jgrossi')->first();
+```
+
+If you need to match multiple meta-fields, you can also use the `hasMeta()` scope passing an array as parameter:
 
 ```php
 $post = Post::hasMeta(['username' => 'jgrossi'])->first();
 $post = Post::hasMeta(['username' => 'jgrossi', 'url' => 'jgrossi.com'])->first();
 // Or just passing the keys
 $post = Post::hasMeta(['username', 'url'])->first();
+```
+
+If you need to match a case-insensitive string, or match with wildcards, you can use the `hasMetaLike()` scope with a value. This uses an SQL `LIKE` operator, so use '%' as a wildcard operator.
+
+```php
+// Will match: 'J Grossi', 'J GROSSI', and 'j grossi'.
+$post = Post::published()->hasMetaLike('author', 'J GROSSI')->first();
+
+// Using % as a wildcard will match: 'J Grossi', 'J GROSSI', 'j grossi', 'Junior Grossi' etc.
+$post = Post::published()->hasMetaLike('author', 'J%GROSSI')->first();
 ```
 
 ### Fields Aliases

--- a/src/Concerns/MetaFields.php
+++ b/src/Concerns/MetaFields.php
@@ -121,17 +121,18 @@ trait MetaFields
         if (!is_array($meta)) {
             $meta = [$meta => $value];
         }
-         foreach ($meta as $key => $value) {
+        foreach ($meta as $key => $value) {
             $query->whereHas('meta', function ($query) use ($key, $value) {
                 if (is_string($key)) {
                     $query->where('meta_key', 'like', $key);
-                     return is_null($value) ? $query : // 'foo' => null
+
+                    return is_null($value) ? $query : // 'foo' => null
                         $query->where('meta_value', 'like', $value); // 'foo' => 'bar'
                 }
-                 return $query->where('meta_key', 'like', $value); // 0 => 'foo'
+                return $query->where('meta_key', 'like', $value); // 0 => 'foo'
             });
         }
-         return $query;
+        return $query;
     }
 
 

--- a/src/Concerns/MetaFields.php
+++ b/src/Concerns/MetaFields.php
@@ -111,6 +111,31 @@ trait MetaFields
     }
 
     /**
+     * @param Builder $query
+     * @param string $meta
+     * @param mixed $value
+     * @return Builder
+     */
+    public function scopeHasMetaLike(Builder $query, $meta, $value = null)
+    {
+        if (!is_array($meta)) {
+            $meta = [$meta => $value];
+        }
+         foreach ($meta as $key => $value) {
+            $query->whereHas('meta', function ($query) use ($key, $value) {
+                if (is_string($key)) {
+                    $query->where('meta_key', 'like', $key);
+                     return is_null($value) ? $query : // 'foo' => null
+                        $query->where('meta_value', 'like', $value); // 'foo' => 'bar'
+                }
+                 return $query->where('meta_key', 'like', $value); // 0 => 'foo'
+            });
+        }
+         return $query;
+    }
+
+
+    /**
      * @param string $key
      * @param mixed $value
      * @return bool

--- a/tests/Unit/Traits/HasMetaFieldsTest.php
+++ b/tests/Unit/Traits/HasMetaFieldsTest.php
@@ -92,20 +92,16 @@ class HasMetaFieldsTest extends \Corcel\Tests\TestCase
     /**
      * @test
      */
-    public function it_can_find_users_by_meta_after_creating_meta()
+    public function it_can_check_meta_using_has_meta_method()
     {
-        $users = [
-            0 => factory(User::class)->create(),
-            1 => factory(User::class)->create(),
-            2 => factory(User::class)->create(),
-            3 => factory(User::class)->create(),
-        ];
-        $users[0]->createMeta(['foo' => 'ba']);
-        $users[1]->createMeta(['foo' => 'bar']);
-        $users[2]->createMeta(['foo' => 'baz']);
-        $users[3]->createMeta(['foo' => 'BA']);
+        factory(User::class)->create()->createMeta(['foo' => 'ba']);
+        factory(User::class)->create()->createMeta(['foo' => 'bar']);
+        factory(User::class)->create()->createMeta(['foo' => 'baz']);
+        factory(User::class)->create()->createMeta(['foo' => 'BA']);
 
+        /** @var Collection $users */
         $users = User::hasMeta(['foo' => 'ba'])->get();
+
         $this->assertInstanceOf(Collection::class, $users);
         $this->assertEquals(1, $users->count());
     }
@@ -115,17 +111,12 @@ class HasMetaFieldsTest extends \Corcel\Tests\TestCase
      */
     public function it_can_find_users_by_meta_like_after_creating_meta()
     {
-        $users = [
-            0 => factory(User::class)->create(),
-            1 => factory(User::class)->create(),
-            2 => factory(User::class)->create(),
-            3 => factory(User::class)->create(),
-        ];
-        $users[0]->createMeta(['foo' => 'ba']);
-        $users[1]->createMeta(['foo' => 'bar']);
-        $users[2]->createMeta(['foo' => 'baz']);
-        $users[3]->createMeta(['foo' => 'BA']);
+        factory(User::class)->create()->createMeta(['foo' => 'ba']);
+        factory(User::class)->create()->createMeta(['foo' => 'bar']);
+        factory(User::class)->create()->createMeta(['foo' => 'baz']);
+        factory(User::class)->create()->createMeta(['foo' => 'BA']);
 
+        /** @var Collection $users */
         $users = User::hasMetaLike(['foo' => 'ba'])->get();
 
         $this->assertInstanceOf(Collection::class, $users);

--- a/tests/Unit/Traits/HasMetaFieldsTest.php
+++ b/tests/Unit/Traits/HasMetaFieldsTest.php
@@ -88,4 +88,69 @@ class HasMetaFieldsTest extends \Corcel\Tests\TestCase
 
         $this->assertEquals('bar', $user->getMeta('foo'));
     }
+
+    /**
+     * @test
+     */
+    public function it_can_find_users_by_meta_after_creating_meta()
+    {
+        $users = [
+            0 => factory(User::class)->create(),
+            1 => factory(User::class)->create(),
+            2 => factory(User::class)->create(),
+            3 => factory(User::class)->create(),
+        ];
+        $users[0]->createMeta(['foo' => 'ba']);
+        $users[1]->createMeta(['foo' => 'bar']);
+        $users[2]->createMeta(['foo' => 'baz']);
+        $users[3]->createMeta(['foo' => 'BA']);
+
+        $users = User::hasMeta(['foo' => 'ba'])->get();
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertEquals(1, $users->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_find_users_by_meta_like_after_creating_meta()
+    {
+        $users = [
+            0 => factory(User::class)->create(),
+            1 => factory(User::class)->create(),
+            2 => factory(User::class)->create(),
+            3 => factory(User::class)->create(),
+        ];
+        $users[0]->createMeta(['foo' => 'ba']);
+        $users[1]->createMeta(['foo' => 'bar']);
+        $users[2]->createMeta(['foo' => 'baz']);
+        $users[3]->createMeta(['foo' => 'BA']);
+
+        $users = User::hasMetaLike(['foo' => 'ba'])->get();
+
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertEquals(2, $users->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_find_users_by_meta_like_with_wildcard_after_creating_meta()
+    {
+        $users = [
+            0 => factory(User::class)->create(),
+            1 => factory(User::class)->create(),
+            2 => factory(User::class)->create(),
+        ];
+        $metas = [
+            $users[0]->createMeta(['foo' => 'ba']),
+            $users[1]->createMeta(['foo' => 'bar']),
+            $users[2]->createMeta(['foo' => 'baz']),
+        ];
+
+        $users = User::hasMetaLike(['foo' => 'ba%'])->get();
+
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertEquals(3, $users->count());
+    }
 }

--- a/tests/Unit/Traits/HasMetaFieldsTest.php
+++ b/tests/Unit/Traits/HasMetaFieldsTest.php
@@ -128,17 +128,11 @@ class HasMetaFieldsTest extends \Corcel\Tests\TestCase
      */
     public function it_can_find_users_by_meta_like_with_wildcard_after_creating_meta()
     {
-        $users = [
-            0 => factory(User::class)->create(),
-            1 => factory(User::class)->create(),
-            2 => factory(User::class)->create(),
-        ];
-        $metas = [
-            $users[0]->createMeta(['foo' => 'ba']),
-            $users[1]->createMeta(['foo' => 'bar']),
-            $users[2]->createMeta(['foo' => 'baz']),
-        ];
+        factory(User::class)->create()->createMeta(['foo' => 'ba']);
+        factory(User::class)->create()->createMeta(['foo' => 'bar']);
+        factory(User::class)->create()->createMeta(['foo' => 'baz']);
 
+        /** @var Collection $users */
         $users = User::hasMetaLike(['foo' => 'ba%'])->get();
 
         $this->assertInstanceOf(Collection::class, $users);


### PR DESCRIPTION
Allow users to do a like search on meta values.

I couldn't figure out an elegant way to do this with Corcel as it currently is, so I added this for our own use.

My current use-cases are doing a case-insensitive search on posts by category, but I can also see wanting to retrieve by "category%".

Usage: you can now retrieve by meta, e.g.:

```
User::hasMeta(['first_name' => 'ADAM'])->get();
User::hasMeta(['full_name' => 'Adam%'])->get();
```

Added tests for this (`hasMetaLike()`) and `hasMeta`.

(Duplicates and supersedes #417.)