### PR TITLE
Allow querying terms with specified taxonomy/taxonomies

### DIFF
--- a/src/Model/Term.php
+++ b/src/Model/Term.php
@@ -39,4 +39,32 @@ class Term extends Model
     {
         return $this->hasOne(Taxonomy::class, 'term_id');
     }
+
+    /**
+     * @param   \Illuminate\Database\Query\Builder  $query
+     * @param   string|array  $taxonomies
+     * @return  void
+     */
+    public function scopeWhereTaxonomy($query, $taxonomies)
+    {
+        if (!is_array($taxonomies)) {
+            $taxonomies = [$taxonomies];
+        }
+
+        $query->whereHas('taxonomy', function ($query) use ($taxonomies) {
+            $query->whereIn('taxonomy', $taxonomies);
+        });
+    }
+
+    /**
+     * Alias of scopeWhereTaxonomy method.
+     *
+     * @param   \Illuminate\Database\Query\Builder  $query
+     * @param   array  $taxonomies
+     * @return  void
+     */
+    public function scopeWhereTaxonomies($query, array $taxonomies = [])
+    {
+        $this->scopeWhereTaxonomy($query, $taxonomies);
+    }
 }

--- a/tests/Unit/Model/TermTest.php
+++ b/tests/Unit/Model/TermTest.php
@@ -2,6 +2,7 @@
 
 namespace Corcel\Tests\Unit\Model;
 
+use Corcel\Model\Taxonomy;
 use Corcel\Model\Term;
 
 /**
@@ -62,5 +63,45 @@ class TermTest extends \Corcel\Tests\TestCase
         $term->saveMeta('fee', 'baz');
 
         return $term;
+    }
+
+    public function test_it_can_be_queried_with_specified_taxonomy()
+    {
+        $this->createTermsAssignedToTaxonomy('foo', 5);
+
+        $terms = Term::whereTaxonomy('foo')->get();
+
+        $this->assertCount(5, $terms);
+        $this->assertInstanceOf(Term::class, $terms->first());
+    }
+
+    public function test_it_can_be_queried_with_specified_taxonomies()
+    {
+        $this->createTermsAssignedToTaxonomy('foo', 5);
+        $this->createTermsAssignedToTaxonomy('bar', 2);
+
+        $terms = Term::whereTaxonomies(['foo', 'bar'])->get();
+
+        $this->assertCount(7, $terms);
+        $this->assertInstanceOf(Term::class, $terms->first());
+    }
+
+    public function test_it_returns_empty_collection_with_unknown_taxonomy()
+    {
+        $this->createTermsAssignedToTaxonomy('foo', 1);
+
+        $terms = Term::whereTaxonomy('unknown')->get();
+
+        $this->assertCount(0, $terms);
+    }
+
+    private function createTermsAssignedToTaxonomy($taxonomy, $termCount)
+    {
+        factory(Taxonomy::class, $termCount)->create([
+            'taxonomy' => $taxonomy,
+            'term_id'  => function () {
+                return factory(Term::class)->create()->term_id;
+            },
+        ]);
     }
 }


### PR DESCRIPTION
Simple helper for querying terms in specified taxonomy/taxonomies. Usage:

```php
Term::whereTaxonomy('foo')->get();
Term::whereTaxonomies(['foo', 'bar'])->get();
```

Of course it can be chained to get only one term in specified taxonomy:

```php
Term::whereTaxonomy('categories')->where('slug', 'projects')->first();
```

Without this code similar or same query could be generated in this way:

```php
 // second where is collection method, not database query
Taxonomy::where('taxonomy', 'categories')->get()
    ->pluck('term')->where('slug', 'projects')->first();

// code copied from this PR
Term::whereHas('taxonomy', function ($query) {
    $query->whereIn('taxonomy', 'category');
})->where('slug', 'projects')->first();
```
