### PR TITLE
Implemented __isset on Post and Taxonomy models, no tests yet

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -403,4 +403,15 @@ class Post extends Model
 
         return $value;
     }
+
+    public function __isset($key)
+    {
+        $value = parent::__isset($key);
+
+        if ($value === false && !property_exists($this, $key)) {
+            return !is_null($this->meta->$key);
+        }
+
+        return $value;
+    }
 }

--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -103,4 +103,15 @@ class Taxonomy extends Model
 
         return parent::__get($key);
     }
+
+    public function __isset($key)
+    {
+        $isset = parent::__get($key);
+
+        if (!$isset) {
+            return isset($this->term->$key) && !is_null($this->term->$key);
+        }
+
+        return $isset;
+    }
 }


### PR DESCRIPTION
Hi,

Thank you for this package, we've been using it quite alot at Impres!

We noticed when accessing meta values directly(`$metaValue = $post->key`). The empty/isset function didn't function as expected. This is because the Taxonomy and Post models implement a magic `__get` method.

According to the PHP documentation the `isset` and `empty` functions use the magic method `__isset` to determine the existence of values when they fetched through `__get`.

This PR adds the `__isset` method to the `Post` and `Taxonomy` classes to make `isset` and `empty` work again.

I noticed that the `CustomLink` also contains a `__get` magic method. Maybe we should also implement `__isset` for this model.

I have not written any tests, and the addition of `__isset` on the `Taxonomy` model seems to have broken the current tests. I will fix these once this PR seems to be an improvement :)





