### PR TITLE
Error on associate term to new taxonomy

### DIFF
--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -96,7 +96,7 @@ class Taxonomy extends Model
     public function __get($key)
     {
         if (!isset($this->$key)) {
-            if (isset($this->term->$key)) {
+            if ($key!="term_id" && isset($this->term->$key)) {
                 return $this->term->$key;
             }
         }


### PR DESCRIPTION
`
$term = new Term();
$term->forceFill([
    'name' => 'My Category',
    'slug' => 'my-category',
    'term_group' => 0,
]);
$term->save();

$category = new Taxonomy();
$category->forceFill([
    'taxonomy' => 'category',
    'description' => '',
    'parent' => 0,
    'count' => 0,
]);
//Here Fail on associate function
$category->term()->associate($term);
$category->save();
`