### PR TITLE
Taxonomy parent/children relation

### DIFF
--- a/src/Model/Taxonomy.php
+++ b/src/Model/Taxonomy.php
@@ -41,7 +41,7 @@ class Taxonomy extends Model
     {
         return $this->hasMany(TermMeta::class, 'term_id');
     }
-    
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
@@ -55,7 +55,15 @@ class Taxonomy extends Model
      */
     public function parent()
     {
-        return $this->belongsTo(Taxonomy::class, 'parent');
+        return $this->belongsTo(Taxonomy::class, 'parent', 'term_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function children()
+    {
+        return $this->hasMany(Taxonomy::class, 'parent', 'term_id');
     }
 
     /**

--- a/tests/Unit/Model/TaxonomyTest.php
+++ b/tests/Unit/Model/TaxonomyTest.php
@@ -116,9 +116,21 @@ class TaxonomyTest extends \Corcel\Tests\TestCase
         /** @var Taxonomy $parent */
         $parent = factory(Taxonomy::class)->create();
         /** @var Taxonomy $taxonomy */
-        $taxonomy = factory(Taxonomy::class)->create(['parent' => $parent->term_taxonomy_id]);
+        $taxonomy = factory(Taxonomy::class)->create(['parent' => $parent->term_id]);
 
         $this->assertEquals($parent->fresh(), $taxonomy->parent()->first());
+    }
+
+    public function test_it_has_children()
+    {
+        /** @var Taxonomy $parent */
+        $parent = factory(Taxonomy::class)->create();
+        /** @var Taxonomy $child1 */
+        $child1 = factory(Taxonomy::class)->create(['parent' => $parent->term_id]);
+        /** @var Taxonomy $child2 */
+        $child2 = factory(Taxonomy::class)->create(['parent' => $parent->term_id]);
+
+        $this->assertEquals([$child1->getKey(), $child2->getKey()], $parent->children->sortBy('term_taxonomy_id')->modelKeys());
     }
 
     private function createTaxonomyWithTermsAndPosts(): Taxonomy


### PR DESCRIPTION
- Fixed `Taxonomy::parent()` relation: the `parent` column should point to the parent's `term_id` and not `term_taxonomy_id`  (that's how WordPress code defines the relation)
- Added `Taxonomy::children()` relation