### PR TITLE
Added missing retrieved event in Post model

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -128,6 +128,8 @@ class Post extends Model
             $connection ?: $this->getConnectionName()
         );
 
+        $model->fireModelEvent('retrieved', false);
+
         return $model;
     }
 


### PR DESCRIPTION
When using events I noticed we're not firing the [retrieved](https://github.com/laravel/framework/blob/d4edbf5f2569c066d6e931cacb3a61d96bdfa313/src/Illuminate/Database/Eloquent/Model.php#L381) event when we have got the Post from the database.
