### PR TITLE
Added static set method to Option model

### DIFF
--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -73,6 +73,26 @@ class Option extends Model
     }
 
     /**
+     * Creates or updates an option based on the $key parameter.
+     * 
+     * @param string $key
+     * @param mixed $value
+     * @return Option
+     */
+    public static function set($key, $value)
+    {
+        return static::updateOrCreate(
+            [
+                'option_name' => $key,
+            ],
+            [
+                'option_name' => $key,
+                'option_value' => is_array($value) ? serialize($value) : $value,
+            ]
+        );
+    }
+
+    /**
      * @param string $name
      * @return mixed
      */

--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -74,7 +74,7 @@ class Option extends Model
 
     /**
      * Creates or updates an option based on the $key parameter.
-     * 
+     *
      * @param string $key
      * @param mixed $value
      * @return Option


### PR DESCRIPTION
Adds a static method to allow creating or updating an option similar to the WordPress [update_option()](https://developer.wordpress.org/reference/functions/update_option/) method