### PR TITLE
fix phpdoc for Metafields@saveMeta to accept array as first parameter

### DIFF
--- a/src/Concerns/MetaFields.php
+++ b/src/Concerns/MetaFields.php
@@ -126,7 +126,7 @@ trait MetaFields
     }
 
     /**
-     * @param string $key
+     * @param string|array $key
      * @param mixed $value
      * @return bool
      */


### PR DESCRIPTION
Just a quick fix for the PHPDoc of the `Metafields@saveMeta` function