### PR TITLE
Fixes MetaCollection __get clash

### DIFF
--- a/src/Model/Collection/MetaCollection.php
+++ b/src/Model/Collection/MetaCollection.php
@@ -15,9 +15,14 @@ class MetaCollection extends Collection
     /**
      * @param string $key
      * @return mixed
+     * @throws \Exception
      */
     public function __get($key)
     {
+        if (in_array($key, static::$proxies)) {
+            return parent::__get($key);
+        }
+
         if (isset($this->items) && count($this->items)) {
             $meta = $this->first(function ($meta) use ($key) {
                 return $meta->meta_key === $key;

--- a/tests/Unit/Model/Meta/PostMetaTest.php
+++ b/tests/Unit/Model/Meta/PostMetaTest.php
@@ -119,6 +119,15 @@ class PostMetaTest extends \Corcel\Tests\TestCase
         $this->assertEquals($post->ID, $newPost->ID);
     }
 
+    public function test_higher_order_functions_can_be_executed()
+    {
+        $post = factory(Post::class)->create();
+        $post->saveMeta('one', 'two');
+        $post->saveMeta('three', 'four');
+
+        $this->assertEquals($post->meta->pluck('value'), collect(['two','four']));
+    }
+
     /**
      * @return PostMeta
      */

--- a/tests/Unit/Model/Meta/PostMetaTest.php
+++ b/tests/Unit/Model/Meta/PostMetaTest.php
@@ -125,7 +125,8 @@ class PostMetaTest extends \Corcel\Tests\TestCase
         $post->saveMeta('one', 'two');
         $post->saveMeta('three', 'four');
 
-        $this->assertEquals($post->meta->pluck('value'), collect(['two','four']));
+        $this->assertEquals($post->meta->map->getQueueableId()->all(), [1, 2]);
+        $this->assertEquals($post->meta->one, 'two');
     }
 
     /**


### PR DESCRIPTION
Fixes #523 

**Background**
There has been a code change in laravel/framework (7.10 onwards) to Illuminate\Database\Eloquent\Collection which introduces the use of the "map" higher order function:
https://github.com/laravel/framework/commit/89bd7e08b47db8004c8dc3908daba60c92e575aa#diff-3f60c3ac71917b0e1e2977c956f6bcc0

MetaCollection overrides the __get function and consumes the "map" call which should get picked up by the EnumeratesValues __get function.
