### PR TITLE
Make service provider to use non-alias version of Auth Facade.

### DIFF
--- a/src/Laravel/CorcelServiceProvider.php
+++ b/src/Laravel/CorcelServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Corcel\Laravel;
 
-use Auth;
 use Corcel\Corcel;
 use Corcel\Laravel\Auth\AuthUserProvider;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
 use Thunder\Shortcode\Parser\RegularParser;
 use Thunder\Shortcode\ShortcodeFacade;


### PR DESCRIPTION
Auth alias can be configured in config/app.php and may differ from "Auth"