### PR TITLE
Refactor generated post_title.

### DIFF
--- a/tests/database/factories/AttachmentFactory.php
+++ b/tests/database/factories/AttachmentFactory.php
@@ -9,7 +9,7 @@ $factory->define(Attachment::class, function (Faker\Generator $faker) {
         'post_date' => $faker->dateTimeThisYear,
         'post_date_gmt' => $faker->dateTimeThisYear,
         'post_content' => $faker->text(),
-        'post_title' => $title = $faker->title,
+        'post_title' => $title = Str::ucfirst($faker->words(3, true)),
         'post_excerpt' => $faker->text(100),
         'post_status' => 'publish',
         'comment_status' => 'closed',

--- a/tests/database/factories/CustomLinkFactory.php
+++ b/tests/database/factories/CustomLinkFactory.php
@@ -9,7 +9,7 @@ $factory->define(CustomLink::class, function (Faker\Generator $faker) {
         'post_date' => $faker->dateTimeThisYear,
         'post_date_gmt' => $faker->dateTimeThisYear,
         'post_content' => $faker->text(),
-        'post_title' => $title = $faker->title,
+        'post_title' => $title = Str::ucfirst($faker->words(3, true)),
         'post_excerpt' => $faker->text(100),
         'post_status' => 'publish',
         'comment_status' => 'closed',

--- a/tests/database/factories/MenuItemFactory.php
+++ b/tests/database/factories/MenuItemFactory.php
@@ -9,7 +9,7 @@ $factory->define(MenuItem::class, function (Faker\Generator $faker) {
         'post_date' => $faker->dateTimeThisYear,
         'post_date_gmt' => $faker->dateTimeThisYear,
         'post_content' => $faker->text(),
-        'post_title' => $title = $faker->title,
+        'post_title' => $title = Str::ucfirst($faker->words(3, true)),
         'post_excerpt' => $faker->text(100),
         'post_status' => 'publish',
         'comment_status' => 'closed',

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -9,7 +9,7 @@ $factory->define(Post::class, function (Faker\Generator $faker) {
         'post_date' => $faker->dateTimeThisYear,
         'post_date_gmt' => $faker->dateTimeThisYear,
         'post_content' => $faker->text(),
-        'post_title' => $title = $faker->title,
+        'post_title' => $title = Str::ucfirst($faker->words(3, true)),
         'post_excerpt' => $faker->text(100),
         'post_status' => 'publish',
         'comment_status' => 'closed',


### PR DESCRIPTION
This pull request changes the generated `post_title` in all factories from `$faker->title` (which is something like _Mr., Ms., Dr., ..._) to a more plausible post title (a random string of three words).