### PR TITLE
Fix PHP Error when Term Taxonomy points to non-existing term_id

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -306,9 +306,13 @@ class Post extends Model
             return $taxonomy->taxonomy == 'post_tag' ?
                 'tag' : $taxonomy->taxonomy;
         })->map(function ($group) {
-            return $group->mapWithKeys(function ($item) {
-                return [$item->term->slug => $item->term->name];
-            });
+            return $group
+                ->filter(function ($item) {
+                    return $item->term !== null;
+                })
+                ->mapWithKeys(function ($item) {
+                    return [$item->term->slug => $item->term->name];
+                });
         })->toArray();
     }
 

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -334,6 +334,26 @@ class PostTest extends \Corcel\Tests\TestCase
         $this->assertEquals('Bar', $post->keywords_str);
     }
 
+    /** @doesNotPerformAssertions */
+    public function test_it_can_handle_corrupted_term()
+    {
+        $post = factory(Post::class)->create();
+
+        $taxonomy = factory(Taxonomy::class)->create([
+            'term_id' => 0,
+            'taxonomy' => 'category'
+        ]);
+
+        $post->taxonomies()->attach(
+            $taxonomy->getKey(),
+            [
+                'term_order' => 0,
+            ]
+        );
+
+        $post->terms;
+    }
+
     public function test_it_can_have_author_relation()
     {
         $post = $this->createPostWithAuthor();


### PR DESCRIPTION
- Corcel Version: 4.0.1
- Framework Name & Version: Laravel 7
- PHP Version: 7.4
- Database Driver & Version: MySQL 

### Description:
If term has been deleted from `terms` table but reference to it left in `term_taxonomy` table, it throws a PHP error when trying to reach `$post->terms` attribute.
Since there are no foreign keys in WP tables, additional checking in code is needed.

### Steps To Reproduce:
PHPUnit test is included in commit.
Create a Taxonomy with term_id = 0 and attach to the Post, try to get $post->terms attribute.