### PR TITLE
(change): concrete to abstract implementation

### DIFF
--- a/src/Corcel.php
+++ b/src/Corcel.php
@@ -2,7 +2,7 @@
 
 namespace Corcel;
 
-use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Foundation\Application;
 
 /**
  * Class Corcel


### PR DESCRIPTION
You are using an concreate implementation of `Illuminate\Foundation\Application`, while using the contract/interface `Illuminate\Contracts\Foundation\Application` allows for less rigid fixation, while still have the desired usage.

We are using a fork of `Application` with the interface; in our case, `Corcel::isLaravel()` returns false because we're not using `Illuminate\Foundation\Application`. However, with this PR, Corcel still works, and everybody who implements the `Application` interface still can enjoy using Corcel.

Should also be propagated to the older version of Corcel of course. If this will be merged, I can also make PR's for older version of Corcel.