### PR TITLE
a package went missing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "^8.0",
         "illuminate/support": "^8.0",
         "fakerphp/faker": "^1.10",
-        "hautelook/phpass": "0.3.*",
+        "castillo-n/phpass": "0.3",
         "thunderer/shortcode": "^0.7.3"
     },
     "require-dev": {


### PR DESCRIPTION
the update points "hautelook/phpass": "0.3.*",: to castillo/phpass:"0.3" which is just a clone from the original phpass. You can as well just clone my cloned repo if you like and discard this pull request. 
Thank you for your time!