### PR TITLE
remove hautelook/phpass for bordoni/phpass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "^6.0",
         "illuminate/support": "^6.0",
         "fzaninotto/faker": "^1.6",
-        "bordoni/phpass": "^0.3.5",
+        "bordoni/phpass": "^0.3.*",
         "thunderer/shortcode": "^0.7.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "^6.0",
         "illuminate/support": "^6.0",
         "fzaninotto/faker": "^1.6",
-        "bordoni/phpass": "dev-main",
+        "bordoni/phpass": "^0.3.5",
         "thunderer/shortcode": "^0.7.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "^6.0",
         "illuminate/support": "^6.0",
         "fzaninotto/faker": "^1.6",
-        "hautelook/phpass": "0.3.*",
+        "bordoni/phpass": "dev-main",
         "thunderer/shortcode": "^0.7.3"
     },
     "require-dev": {


### PR DESCRIPTION
removed  "hautelook/phpass": "0.3.*". hautelook/phpass is a 404 now.
 added  "bordoni/phpass": "^0.3.*" is a fork of the original repo