### PR TITLE
fix: Get empty string when attachment is null

### DIFF
--- a/src/Model/Meta/ThumbnailMeta.php
+++ b/src/Model/Meta/ThumbnailMeta.php
@@ -61,6 +61,6 @@ class ThumbnailMeta extends PostMeta
      */
     public function __toString()
     {
-        return $this->attachment->guid;
+        return $this->attachment->guid ?? '';
     }
 }


### PR DESCRIPTION
Return an empty string for the thumbnail url if the "attachment" is null