### PR TITLE
Add autoload and update support for option

### DIFF
--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -63,15 +63,16 @@ class Option extends Model
      * @param string $key
      * @param mixed $value
      * @param bool $autoload
+     *
      * @return Option
      */
     public static function add($key, $value, $autoload = true)
     {
         return static::updateOrCreate([
             'option_name' => $key,
-        ],[
+        ], [
             'option_value' => is_array($value) ? serialize($value) : $value,
-            'autoload' => $autoload ? "yes" : "no"
+            'autoload'     => $autoload ? "yes" : "no"
         ]);
     }
 

--- a/src/Model/Option.php
+++ b/src/Model/Option.php
@@ -62,13 +62,16 @@ class Option extends Model
     /**
      * @param string $key
      * @param mixed $value
+     * @param bool $autoload
      * @return Option
      */
-    public static function add($key, $value)
+    public static function add($key, $value, $autoload = true)
     {
-        return static::create([
+        return static::updateOrCreate([
             'option_name' => $key,
+        ],[
             'option_value' => is_array($value) ? serialize($value) : $value,
+            'autoload' => $autoload ? "yes" : "no"
         ]);
     }
 


### PR DESCRIPTION
Here's a simple example : 

```php
        $debugPrint = function (Option $option) {
            dump([
                "option_id" => $option->option_id,
                "option_name" => $option->option_name,
                "option_value" => $option->option_value,
                "autoload" => $option->autoload,
            ]);
        };
        Option::add("hellooo", "ok");
        $debugPrint(Option::where("option_name", "hellooo")->first());
        Option::add("hellooo", "ok2");
        $debugPrint(Option::where("option_name", "hellooo")->first());
        Option::add("hellooo", "ok3", false);
        $debugPrint(Option::where("option_name", "hellooo")->first());
        exit(0);
```

Output:

```bash
array:4 [
  "option_id" => 4736
  "option_name" => "hellooo"
  "option_value" => "ok"
  "autoload" => "yes"
]
array:4 [
  "option_id" => 4736
  "option_name" => "hellooo"
  "option_value" => "ok2"
  "autoload" => "yes"
]
array:4 [
  "option_id" => 4736
  "option_name" => "hellooo"
  "option_value" => "ok3"
  "autoload" => "no"
]
```