### PR TITLE
Adding description to User appends for easier access

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -82,6 +82,7 @@ class User extends Model implements Authenticatable, CanResetPassword
         'first_name',
         'last_name',
         'avatar',
+        'description',
         'created_at',
     ];
 


### PR DESCRIPTION
When interacting with the User model, description is the only attribute which is aliased but not included in the appends.  So despite the alias making it easier to access it is not eager loaded.  The meta is already eager loaded, so this would not be any hit to performance to include it in the appends.