### PR TITLE
Fix for WP 6.8

### DIFF
--- a/src/Services/PasswordService.php
+++ b/src/Services/PasswordService.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Corcel\Services;
-
+use Corcel\Model\Option;
 use Hautelook\Phpass\PasswordHash;
 
 /**
@@ -26,7 +26,25 @@ class PasswordService
      */
     public function makeHash($password)
     {
-        return $this->hasher->HashPassword(trim($password));
+		$dbVersion = Option::where('option_name', 'db_version')->first()->option_value;
+		$isAtLeast68 = $dbVersion >= 58975;
+
+		if ($isAtLeast68) {
+			$password_to_hash = base64_encode( hash_hmac( 'sha384', trim( $password ), 'wp-sha384', true ) );
+
+			// Default $options: WordPress 6.8 uses ['cost' => 10] for bcrypt
+			// This can be overwritten by $options = apply_filters( 'wp_hash_password_options', array(), $algorithm ); though!
+			$options = array( 'cost' => 10  );	
+
+            // Add a prefix to facilitate distinguishing vanilla bcrypt hashes.
+            $hashedPassword = '$wp' . password_hash( $password_to_hash, PASSWORD_BCRYPT, $options);
+						
+			return $hashedPassword;
+		}
+		else {
+			return $this->hasher->HashPassword(trim($password));
+		}
+        
     }
 
     /**
@@ -38,8 +56,15 @@ class PasswordService
      */
     public function check($password, $hash)
     {
+		
         if (strlen($hash) <= 32) { // if the hash is still md5
             return $hash === md5($password);
+        }
+        if (str_starts_with($hash, '$wp')) // fix for 6.8 wordpress 
+        {
+            $password_to_verify = base64_encode( hash_hmac( 'sha384', $password, 'wp-sha384', true ) );
+			
+            return password_verify( $password_to_verify, substr( $hash, 3 ) );
         }
 
         return $this->hasher->CheckPassword($password, $hash);


### PR DESCRIPTION
This fix will check for WP 6.8 compatible passwords and use the new algorithm to check if the password is correct.
The makeHash function doesn't account for any overrides of the default BCRYPT options though as it can be overwritten by $options = apply_filters( 'wp_hash_password_options', array(), $algorithm );