### PR TITLE
Improved logic of getMeta function.

### DIFF
--- a/src/Concerns/MetaFields.php
+++ b/src/Concerns/MetaFields.php
@@ -208,10 +208,8 @@ trait MetaFields
      */
     public function getMeta($attribute)
     {
-        if ($meta = $this->meta->{$attribute}) {
-            return $meta;
-        }
+        $meta = $this->meta->{$attribute};
 
-        return null;
+        return $meta ?? null;
     }
 }


### PR DESCRIPTION
Fix the logic of getMeta function to return values like 0, false. Right now if the meta value is 0 it returns null.

Result of Previous Logic
![image](https://github.com/user-attachments/assets/9a910cc4-c91c-41db-8bd8-f497cda517a3)

Result of Updated Logic
![image](https://github.com/user-attachments/assets/fd3fda4a-7708-499d-928c-640505971574)
